### PR TITLE
Fix lucide icon import

### DIFF
--- a/src/components/maintenance/VehicleMaintenanceCards.tsx
+++ b/src/components/maintenance/VehicleMaintenanceCards.tsx
@@ -4,7 +4,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { useNavigate } from 'react-router-dom';
 import { format } from 'date-fns';
-import { AlertTriangle, Car, Clock, Settings, Wrench, Calendar, Tools } from 'lucide-react';
+import { AlertTriangle, Car, Clock, Settings, Wrench, Calendar, Tool } from 'lucide-react';
 
 interface Vehicle {
   id: string;
@@ -58,7 +58,7 @@ const VehicleMaintenanceCards = ({ vehicles, isLoading = false }: VehicleMainten
   const getMaintenanceTypeIcon = (type: string) => {
     switch(type?.toLowerCase()) {
       case 'oil change':
-        return <Tools className="h-4 w-4 mr-1" />;
+        return <Tool className="h-4 w-4 mr-1" />;
       default:
         return <Wrench className="h-4 w-4 mr-1" />;
     }


### PR DESCRIPTION
## Summary
- replace missing `Tools` icon with `Tool` in maintenance cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)* 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR fixes a bug by replacing the deprecated 'Tools' icon with the correct 'Tool' icon in the VehicleMaintenanceCards component. The update also improves the logic for maintenance type icon selection, enhancing code stability and maintainability while resolving build errors.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>