### PR TITLE
Add doc on monolith service boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,7 @@ Simply open [Lovable](https://lovable.dev/projects/3443e083-f60b-43c2-aa17-354a2
 ## I want to use a custom domain - is that possible?
 
 We don't support custom domains (yet). If you want to deploy your project under your own domain then we recommend using Netlify. Visit our docs for more details: [Custom domains](https://docs.lovable.dev/tips-tricks/custom-domain/)
+
+## Service Boundaries
+
+For an overview of how domain logic is organized within the monolithic repository, see [docs/service-boundaries.md](docs/service-boundaries.md). Following these boundaries helps keep each feature cohesive and prepares the system for future microservice extraction.

--- a/docs/service-boundaries.md
+++ b/docs/service-boundaries.md
@@ -1,0 +1,23 @@
+# Service Boundaries
+
+This document outlines the logical service boundaries within the monolithic codebase. Each service corresponds to a cohesive domain of the rental management system. Keeping responsibilities well separated helps us migrate features to standalone services in the future.
+
+## Overview
+
+The monolith currently organizes domain logic under `src/services`. Each file exposes business operations for a specific domain:
+
+- **CustomerService** – customer records and profile management
+- **VehicleService** – fleet information and maintenance history
+- **AgreementService** – rental agreements and lifecycle actions
+- **PaymentService** – payment processing and billing
+
+While they live in a single repository, treat each service as an independent boundary with its own database tables and types. Avoid cross‑service data access and share data only through well-defined interfaces.
+
+## Guidelines
+
+1. **No direct data access across services**. A service should read and write only the tables that belong to its domain. Use service method calls when another part of the system needs that data.
+2. **Explicit exports**. Each service exposes a small public API. Internal helpers should remain private to the module.
+3. **Folder structure**. Services are placed under `src/services`. Subfolders may be used to group related files (repositories, types) inside each domain.
+4. **Future extraction**. By honouring these boundaries, we can extract any of the services to its own microservice with minimal changes.
+
+Refer to this document when adding new features or refactoring existing ones. Ensure that new domain logic fits clearly within one of the existing service boundaries or create a new boundary if necessary.


### PR DESCRIPTION
## Summary
- document domain service boundaries
- reference service boundaries in README

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*