### PR TITLE
Add internal event bus

### DIFF
--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,0 +1,11 @@
+export const Events = {
+  PaymentRecorded: 'payment.recorded'
+} as const;
+
+export type EventName = (typeof Events)[keyof typeof Events];
+
+export interface PaymentRecordedPayload {
+  paymentId: string;
+  agreementId: string;
+  amount: number;
+}

--- a/src/events/payment-handlers.ts
+++ b/src/events/payment-handlers.ts
@@ -1,0 +1,15 @@
+import { eventBus } from '@/lib/event-bus';
+import { supabase } from '@/lib/supabase';
+import { Events, PaymentRecordedPayload } from './index';
+
+export function registerPaymentEventHandlers() {
+  eventBus.subscribe<PaymentRecordedPayload>(
+    Events.PaymentRecorded,
+    async (payload) => {
+      await supabase
+        .from('leases')
+        .update({ last_payment_date: new Date().toISOString() })
+        .eq('id', payload.agreementId);
+    }
+  );
+}

--- a/src/lib/event-bus.ts
+++ b/src/lib/event-bus.ts
@@ -1,0 +1,30 @@
+export type EventHandler<T> = (payload: T) => void;
+
+class EventBus {
+  private handlers = new Map<string, EventHandler<any>[]>();
+
+  subscribe<T>(event: string, handler: EventHandler<T>): () => void {
+    const existing = this.handlers.get(event) || [];
+    existing.push(handler as EventHandler<any>);
+    this.handlers.set(event, existing);
+    return () => this.unsubscribe(event, handler);
+  }
+
+  publish<T>(event: string, payload: T): void {
+    const handlers = this.handlers.get(event);
+    if (!handlers) return;
+    handlers.forEach(h => h(payload));
+  }
+
+  unsubscribe<T>(event: string, handler: EventHandler<T>): void {
+    const handlers = this.handlers.get(event);
+    if (!handlers) return;
+    const index = handlers.indexOf(handler as EventHandler<any>);
+    if (index >= 0) {
+      handlers.splice(index, 1);
+    }
+  }
+}
+
+export const eventBus = new EventBus();
+export default EventBus;

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -1,5 +1,7 @@
 
 import { supabase } from '@/lib/supabase';
+import { eventBus } from '@/lib/event-bus';
+import { Events, PaymentRecordedPayload } from '@/events';
 import { castDbId } from '@/utils/supabase-type-helpers';
 import { BaseService } from './base/BaseService';
 import { Payment, PaymentInsert, SpecialPaymentOptions } from '@/types/payment.types';
@@ -20,7 +22,16 @@ export class PaymentService extends BaseService {
       if (error) {
         return this.handleError(error, 'Failed to record payment');
       }
-      
+
+      if (data) {
+        const payload: PaymentRecordedPayload = {
+          paymentId: data.id,
+          agreementId: data.lease_id,
+          amount: data.amount_paid ?? data.amount
+        };
+        eventBus.publish(Events.PaymentRecorded, payload);
+      }
+
       return this.success(data);
     } catch (error) {
       return this.handleError(error, 'An unexpected error occurred recording payment');

--- a/src/utils/app-initializer.ts
+++ b/src/utils/app-initializer.ts
@@ -3,11 +3,13 @@ import { setupInvoiceTemplatesTable } from "./setupInvoiceTemplates";
 import { supabase } from '@/lib/supabase';
 import { toast } from 'sonner';
 import { getSystemServicesStatus } from './service-availability';
+import { registerPaymentEventHandlers } from '@/events/payment-handlers';
 
 // Initialize services check status flag
 let servicesChecked = false;
 
 export const initializeApp = async () => {
+  registerPaymentEventHandlers();
   // Set up database tables and other requirements
   await setupInvoiceTemplatesTable();
   


### PR DESCRIPTION
## Summary
- implement simple event bus
- define payment events
- emit event after recording a payment
- update agreements via event handler
- register the handler during app startup

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*