### PR TITLE
Fix docs typos, toast cleanup and add pagination tests

### DIFF
--- a/Vehicle_Maintenance.md
+++ b/Vehicle_Maintenance.md
@@ -185,7 +185,7 @@ Key maintenance workflows have automated tests:
 3. Parts allocation
 4. Cost calculation
 
-Test suite location: `src/tests/maintenance/`
+*Note:* Automated tests for these workflows have not yet been implemented.
 
 ## Configuration Parameters
 

--- a/docs/manual-testing-guide.md
+++ b/docs/manual-testing-guide.md
@@ -6,7 +6,7 @@ This guide provides detailed steps to manually test all functionality after the 
 
 1. Start the application:
 ```
-cd "c:\Users\khamis\coodebase rental\rental-solutions-28bf4163"
+cd "c:\Users\khamis\codebase rental\rental-solutions-28bf4163"
 npm run dev
 ```
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -88,6 +89,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^1.5.0"
   }
 }

--- a/scripts/test-migration.ps1
+++ b/scripts/test-migration.ps1
@@ -7,7 +7,7 @@ Write-Host "This script will test the core functionality of migrated services" -
 Write-Host ""
 
 # Navigate to project directory
-Set-Location "c:\Users\khamis\coodebase rental\rental-solutions-28bf4163"
+Set-Location "c:\Users\khamis\codebase rental\rental-solutions-28bf4163"
 
 # Step 1: Run type checking to verify no type errors
 Write-Host "Step 1: Running TypeScript type checking..." -ForegroundColor Green

--- a/src/hooks/__tests__/usePagination.test.ts
+++ b/src/hooks/__tests__/usePagination.test.ts
@@ -1,0 +1,20 @@
+import { renderHook, act } from '@testing-library/react'
+import { usePagination } from '../usePagination'
+
+describe('usePagination', () => {
+  it('resets current page to valid bounds on init', () => {
+    const { result } = renderHook(() =>
+      usePagination({ totalItems: 30, initialPage: 10, itemsPerPage: 10 })
+    )
+    expect(result.current.currentPage).toBe(3)
+  })
+
+  it('resets page to 1 when items per page changes', () => {
+    const { result } = renderHook(() =>
+      usePagination({ totalItems: 30, initialPage: 2, itemsPerPage: 10 })
+    )
+    act(() => result.current.setItemsPerPage(5))
+    expect(result.current.currentPage).toBe(1)
+    expect(result.current.itemsPerPage).toBe(5)
+  })
+})

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix manual testing guide and script path typos
- ensure toast listener only registers once
- clarify maintenance docs about missing tests
- add vitest test script and pagination tests

## Testing
- `npm test` *(fails: vitest not found)* 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR implements targeted improvements including a typo fix in the migration script and optimization of toast listener cleanup. It adds new tests for the pagination hook to verify proper behavior when pagination parameters change. These changes enhance code quality and test coverage.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>