### PR TITLE
Fix missing value for CommandItem

### DIFF
--- a/src/components/agreements/form/CustomerVehicleSection.tsx
+++ b/src/components/agreements/form/CustomerVehicleSection.tsx
@@ -123,6 +123,7 @@ export const CustomerVehicleSection: React.FC<CustomerVehicleSectionProps> = ({
                 {safeCustomers.map((customer) => (
                   <CommandItem
                     key={customer.id}
+                    value={customer.full_name}
                     onSelect={() => {
                       setSelectedCustomer(customer);
                       setOpen(false);


### PR DESCRIPTION
## Summary
- ensure every CommandItem has a `value` so `cmdk` doesn't crash

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*