### PR TITLE
Fix agreement creation bug

### DIFF
--- a/src/components/agreements/edit/AgreementEditor.tsx
+++ b/src/components/agreements/edit/AgreementEditor.tsx
@@ -153,7 +153,7 @@ const AgreementEditor = () => {
         });
       } else {
         // Create new agreement
-        result = await agreementService.save(data);
+        result = await agreementService.createAgreement(data);
       }
       
       if (result) {


### PR DESCRIPTION
## Summary
- use `createAgreement` from `useAgreementService`

## Testing
- `npm install` *(fails: Exit handler never called)*