### PR TITLE
Fix missing CommandList imports

### DIFF
--- a/src/components/agreements/form/CustomerVehicleSection.tsx
+++ b/src/components/agreements/form/CustomerVehicleSection.tsx
@@ -4,7 +4,7 @@ import { CustomerInfo } from "@/types/customer";
 import VehicleSelector from "@/components/vehicles/VehicleSelector";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertCircle } from "lucide-react";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from '@/components/ui/command';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Button } from '@/components/ui/button';
 import { Check, ChevronsUpDown } from 'lucide-react';

--- a/src/components/customers/CustomerSelector.tsx
+++ b/src/components/customers/CustomerSelector.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from '@/components/ui/command';
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Button } from '@/components/ui/button';
 import { Check, ChevronsUpDown, Loader2 } from 'lucide-react';

--- a/src/components/vehicles/VehicleSelector.tsx
+++ b/src/components/vehicles/VehicleSelector.tsx
@@ -9,6 +9,7 @@ import {
   CommandGroup,
   CommandInput,
   CommandItem,
+  CommandList,
 } from "@/components/ui/command";
 import {
   Popover,


### PR DESCRIPTION
## Summary
- import `CommandList` in various selector components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run check-boundaries`