### PR TITLE
Fix vehicle agreement query and duplicate button

### DIFF
--- a/src/components/vehicles/detail/VehicleQuickActions.tsx
+++ b/src/components/vehicles/detail/VehicleQuickActions.tsx
@@ -31,15 +31,6 @@ export const VehicleQuickActions: React.FC<VehicleQuickActionsProps> = ({ vehicl
         <Button 
           variant="outline" 
           className="w-full justify-start"
-          onClick={() => navigate(`/agreements/add?vehicle_id=${vehicle.id}`)}
-          disabled={!isAvailable}
-        >
-          <FileText className="mr-2 h-4 w-4" />
-          Create New Agreement
-        </Button>
-        <Button 
-          variant="outline" 
-          className="w-full justify-start"
           onClick={() => navigate(`/vehicles/edit/${vehicle.id}`)}
         >
           <Edit className="mr-2 h-4 w-4" />

--- a/src/hooks/use-vehicle-agreements.ts
+++ b/src/hooks/use-vehicle-agreements.ts
@@ -14,7 +14,7 @@ export function useVehicleAgreements(vehicleId?: string) {
       
       const { data, error } = await supabase
         .from('leases')
-        .select('*, customers(full_name)')
+        .select('*, customers:profiles(full_name)')
         .eq('vehicle_id', asVehicleId(vehicleId))
         .order('created_at', { ascending: false });
       


### PR DESCRIPTION
## Summary
- update vehicle agreement hook to join with profiles table
- remove extra "Create New Agreement" button from vehicle quick actions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run check-boundaries`
