### PR TITLE
Fix type guard references

### DIFF
--- a/src/lib/database-types.ts
+++ b/src/lib/database-types.ts
@@ -1,6 +1,7 @@
 
 import { PostgrestSingleResponse, PostgrestResponse } from '@supabase/supabase-js';
 import { Database } from '@/types/database.types';
+export { isSuccessResponse } from './database/validation/typeGuards';
 
 // Helper type for easy table access
 export type Tables = Database['public']['Tables'];
@@ -25,11 +26,6 @@ export function handleDatabaseResponse<T>(response: PostgrestResponse<T> | Postg
 }
 
 // Type guard for responses
-export function isSuccessResponse<T>(
-  response: PostgrestResponse<T> | PostgrestSingleResponse<T>
-): response is { data: T | T[]; error: null } {
-  return !response.error && response.data !== null;
-}
 
 // Type safe ID converter
 export function asTableId<T extends keyof Tables>(table: T, id: string): Tables[T]['Row']['id'] {

--- a/src/types/database-common.ts
+++ b/src/types/database-common.ts
@@ -1,5 +1,6 @@
 
 import { Database } from '@/types/database.types';
+export { isSuccessResponse } from '@/lib/database/validation/typeGuards';
 
 // Core database types with consistent naming
 export type DatabaseSchema = Database['public'];
@@ -108,10 +109,6 @@ export type ListResponse<T> = DatabaseResponse<T[]>;
 export type SingleResponse<T> = DatabaseResponse<T>;
 
 // Helper type guards with consistent naming
-export function isSuccessResponse<T>(response: any): response is { data: T; error: null } {
-  return !response?.error && response?.data !== null;
-}
-
 export function hasEntityData<T>(response: any): response is { data: T; error: null } {
   return !response?.error && response?.data !== null;
 }


### PR DESCRIPTION
## Summary
- unify success response type guard exports

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run check-boundaries`