### PR TITLE
Fix React entrypoint

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,14 @@
 
 import { createRoot } from 'react-dom/client';
+import ReactDOMLegacy from 'react-dom';
 import App from './App.tsx';
 import './index.css';
 
-createRoot(document.getElementById("root")!).render(
-  <App />
-);
+const rootElement = document.getElementById('root');
+if (rootElement) {
+  if (typeof createRoot === 'function') {
+    createRoot(rootElement).render(<App />);
+  } else {
+    ReactDOMLegacy.render(<App />, rootElement);
+  }
+}


### PR DESCRIPTION
## Summary
- use a fallback for ReactDOM.render if `createRoot` isn't available

## Testing
- `npm run build` *(fails: `vite: not found`)*