### PR TITLE
Fix license plate filter vehicles join

### DIFF
--- a/src/services/AgreementService.ts
+++ b/src/services/AgreementService.ts
@@ -134,11 +134,12 @@ export const agreementService = {
    */
   async findAgreements(filters: AgreementFilters = {}): Promise<SaveResponse> {
     try {
-      let query = supabase.from('leases').select(`
+      const selectClause = `
         *,
         customers:profiles(*),
-        vehicles(*)
-      `);
+        vehicles${filters.license_plate ? '!inner' : ''}(*)
+      `;
+      let query = supabase.from('leases').select(selectClause);
       
       // Apply filters
       if (filters.status && filters.status !== 'all') {


### PR DESCRIPTION
## Summary
- ensure join to vehicles table uses inner join when filtering by license plate

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*