### PR TITLE
Finalize lease agreement workflow

### DIFF
--- a/src/components/agreements/AgreementFormWithVehicleCheck.tsx
+++ b/src/components/agreements/AgreementFormWithVehicleCheck.tsx
@@ -37,12 +37,8 @@ const paymentFrequencyOptions = [
 ];
 
 const agreementTypeOptions = [
-  { value: 'lease', label: 'Lease' },
-  { value: 'rental', label: 'Rental' },
-  { value: 'service', label: 'Service' },
-  { value: 'sales', label: 'Sales' },
-  { value: 'partnership', label: 'Partnership' },
-  { value: 'other', label: 'Other' },
+  { value: 'short_term', label: 'Short Term' },
+  { value: 'lease_to_own', label: 'Lease to Own' },
 ];
 
 // Define the actual component with a minimal implementation
@@ -53,7 +49,7 @@ const AgreementFormWithVehicleCheck: React.FC<AgreementFormWithVehicleCheckProps
   isCheckingTemplate = false 
 }) => {
   const [formData, setFormData] = React.useState({
-    agreement_type: 'lease',
+    agreement_type: 'short_term',
     status: 'pending',
     payment_frequency: 'monthly',
   });

--- a/src/components/agreements/edit/AgreementEditor.tsx
+++ b/src/components/agreements/edit/AgreementEditor.tsx
@@ -33,11 +33,13 @@ import CustomerSelector from '@/components/customers/CustomerSelector';
 import PaymentScheduleEditor from '../payments/PaymentScheduleEditor';
 import AgreementTermsEditor from '../terms/AgreementTermsEditor';
 import { CustomerInfo } from '@/types/customer';
+import { useAgreementTemplates } from '@/hooks/use-agreement-templates';
 
 // Define the validation schema
 const agreementSchema = z.object({
   agreement_number: z.string().optional(),
-  agreement_type: z.string().min(1, "Agreement type is required"),
+  agreement_type: z.enum(['short_term', 'lease_to_own']).optional(),
+  template_id: z.string().optional(),
   status: z.string().min(1, "Status is required"),
   customer_id: z.string().min(1, "Customer is required"),
   vehicle_id: z.string().min(1, "Vehicle is required"),
@@ -62,6 +64,7 @@ const AgreementEditor = () => {
   const [activeTab, setActiveTab] = useState("details");
   const [selectedCustomer, setSelectedCustomer] = useState<CustomerInfo | null>(null);
   const [selectedVehicle, setSelectedVehicle] = useState<any>(null);
+  const { data: templates } = useAgreementTemplates();
   
   const agreementService = useAgreementService();
   
@@ -70,7 +73,8 @@ const AgreementEditor = () => {
     resolver: zodResolver(agreementSchema),
     defaultValues: {
       agreement_number: '',
-      agreement_type: 'rental',
+      agreement_type: 'short_term',
+      template_id: '',
       status: 'draft',
       customer_id: '',
       vehicle_id: '',
@@ -103,7 +107,8 @@ const AgreementEditor = () => {
           
           form.reset({
             agreement_number: agreement.agreement_number || '',
-            agreement_type: agreement.agreement_type || 'rental',
+            agreement_type: agreement.agreement_type || 'short_term',
+            template_id: agreement.template_id || '',
             status: agreement.status || 'draft',
             customer_id: agreement.customer_id || '',
             vehicle_id: agreement.vehicle_id || '',
@@ -271,10 +276,34 @@ const AgreementEditor = () => {
                               </SelectTrigger>
                             </FormControl>
                             <SelectContent>
-                              <SelectItem value="rental">Rental</SelectItem>
-                              <SelectItem value="lease">Lease</SelectItem>
-                              <SelectItem value="finance">Finance</SelectItem>
-                              <SelectItem value="subscription">Subscription</SelectItem>
+                              <SelectItem value="short_term">Short Term</SelectItem>
+                              <SelectItem value="lease_to_own">Lease to Own</SelectItem>
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="template_id"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Template</FormLabel>
+                          <Select
+                            onValueChange={field.onChange}
+                            defaultValue={field.value}
+                          >
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select template" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {templates?.map(t => (
+                                <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+                              ))}
                             </SelectContent>
                           </Select>
                           <FormMessage />

--- a/src/hooks/use-agreement-status.ts
+++ b/src/hooks/use-agreement-status.ts
@@ -30,6 +30,23 @@ export const useAgreementStatus = (agreement: Agreement | null, agreementId: str
       return false;
     }
     
+    const currentStatus = agreement?.status as AgreementStatus | undefined;
+
+    const allowedTransitions: Record<AgreementStatus, AgreementStatus[]> = {
+      draft: ['active', 'cancelled'],
+      active: ['completed', 'cancelled', 'closed'],
+      pending: ['active', 'cancelled'],
+      expired: [],
+      cancelled: [],
+      closed: [],
+      completed: []
+    };
+
+    if (currentStatus && !allowedTransitions[currentStatus]?.includes(newStatus as AgreementStatus)) {
+      toast.error(`Cannot change status from ${currentStatus} to ${newStatus}`);
+      return false;
+    }
+
     setIsProcessing(true);
     setStatusUpdateProgress("Preparing status update...");
     

--- a/src/hooks/use-agreement-templates.ts
+++ b/src/hooks/use-agreement-templates.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/lib/supabase';
+
+export interface AgreementTemplate {
+  id: string;
+  name: string;
+}
+
+export function useAgreementTemplates() {
+  return useQuery({
+    queryKey: ['agreementTemplates'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('agreement_templates')
+        .select('id, name')
+        .eq('is_active', true)
+        .order('name', { ascending: true });
+      if (error) throw error;
+      return data as AgreementTemplate[];
+    }
+  });
+}

--- a/src/lib/validation-schemas/agreement.ts
+++ b/src/lib/validation-schemas/agreement.ts
@@ -2,7 +2,7 @@
 import { toast } from 'sonner';
 import { SupabaseClient } from '@supabase/supabase-js';
 import { z } from 'zod';
-import { ValidationLeaseStatus } from '@/types/lease-types';
+import { ValidationLeaseStatus, AgreementType } from '@/types/lease-types';
 
 // Enum for agreement status
 export const AgreementStatus = {
@@ -21,6 +21,8 @@ export const agreementSchema = z.object({
   end_date: z.date(),
   customer_id: z.string().min(1, "Customer is required"),
   vehicle_id: z.string().min(1, "Vehicle is required"),
+  agreement_type: z.enum(['short_term', 'lease_to_own']).optional(),
+  template_id: z.string().optional(),
   status: z.enum(["draft", "active", "pending", "expired", "cancelled", "closed"]) as z.ZodEnum<[ValidationLeaseStatus, ...ValidationLeaseStatus[]]>,
   rent_amount: z.number().positive("Rent amount must be positive"),
   deposit_amount: z.number().nonnegative("Deposit amount must be non-negative"),
@@ -57,7 +59,7 @@ export interface Agreement {
   vehicle_id: string;
   start_date: Date;
   end_date: Date;
-  agreement_type?: string;
+  agreement_type?: AgreementType;
   agreement_number?: string;
   status: typeof AgreementStatus[keyof typeof AgreementStatus];
   total_amount?: number;
@@ -68,6 +70,7 @@ export interface Agreement {
   vehicle_make?: string;
   vehicle_model?: string;
   vehicle_year?: number;
+  template_id?: string;
   created_at?: Date;
   updated_at?: Date;
   signature_url?: string;

--- a/src/services/AgreementService.ts
+++ b/src/services/AgreementService.ts
@@ -55,11 +55,12 @@ export const agreementService = {
             total_amount: agreement.total_amount,
             rent_amount: agreement.rent_amount,
             daily_late_fee: agreement.daily_late_fee,
-            agreement_type: agreement.agreement_type,
+            agreement_type: agreement.agreement_type || 'short_term',
             agreement_duration: agreement.agreement_duration,
             rent_due_day:
               (agreement as any).payment_day ?? (agreement as any).rent_due_day,
             notes: agreement.notes,
+            template_id: (agreement as any).template_id || null,
             updated_at: new Date().toISOString()
           })
           .eq('id', asLeaseId(agreement.id!))
@@ -85,11 +86,12 @@ export const agreementService = {
             total_amount: agreement.total_amount,
             rent_amount: agreement.rent_amount,
             daily_late_fee: agreement.daily_late_fee,
-            agreement_type: agreement.agreement_type || 'rental',
+            agreement_type: agreement.agreement_type || 'short_term',
             agreement_duration: agreement.agreement_duration,
             rent_due_day:
               (agreement as any).payment_day ?? (agreement as any).rent_due_day,
-            notes: agreement.notes
+            notes: agreement.notes,
+            template_id: (agreement as any).template_id || null
           })
           .select()
           .single();

--- a/src/types/agreement.ts
+++ b/src/types/agreement.ts
@@ -1,5 +1,5 @@
 
-import { LeaseStatus } from '@/types/lease-types';
+import { LeaseStatus, AgreementType } from '@/types/lease-types';
 
 export interface Agreement {
   id: string;
@@ -15,7 +15,8 @@ export interface Agreement {
   created_at?: Date;
   updated_at?: Date;
   agreement_number?: string;
-  agreement_type?: string;
+  agreement_type?: AgreementType;
+  template_id?: string;
   next_payment_date?: string;
   last_payment_date?: string;
   notes?: string;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -14,7 +14,7 @@ export interface Database {
           total_amount: number;
           deposit_amount: number | null;
           daily_late_fee: number | null;
-          agreement_type: 'short_term' | 'long_term' | 'rental' | 'lease_to_own';
+          agreement_type: 'short_term' | 'lease_to_own';
           agreement_duration: unknown;
           rent_due_day: number | null;
           notes: string | null;
@@ -34,7 +34,7 @@ export interface Database {
           total_amount: number;
           deposit_amount?: number | null;
           daily_late_fee?: number | null;
-          agreement_type: 'short_term' | 'long_term' | 'rental' | 'lease_to_own';
+          agreement_type: 'short_term' | 'lease_to_own';
           agreement_duration: unknown;
           rent_due_day?: number | null;
           notes?: string | null;
@@ -51,7 +51,7 @@ export interface Database {
           total_amount?: number;
           deposit_amount?: number | null;
           daily_late_fee?: number | null;
-          agreement_type?: 'short_term' | 'long_term' | 'rental' | 'lease_to_own';
+          agreement_type?: 'short_term' | 'lease_to_own';
           agreement_duration?: unknown;
           rent_due_day?: number | null;
           notes?: string | null;

--- a/src/types/lease-types.ts
+++ b/src/types/lease-types.ts
@@ -16,13 +16,25 @@ export type LeaseStatus =
  * Subset of lease status values used for validation
  * These are the accepted values in forms and validation schemas
  */
-export type ValidationLeaseStatus = 
-  | 'draft' 
-  | 'active' 
-  | 'pending' 
-  | 'expired' 
-  | 'cancelled' 
+export type ValidationLeaseStatus =
+  | 'draft'
+  | 'active'
+  | 'pending'
+  | 'expired'
+  | 'cancelled'
   | 'closed';
+
+/**
+ * Agreement type enum matching database values
+ */
+export type AgreementType = 'short_term' | 'lease_to_own';
+
+/**
+ * Ensure a valid agreement type, defaulting to 'short_term'
+ */
+export function ensureAgreementType(type: string | null | undefined): AgreementType {
+  return type === 'lease_to_own' ? 'lease_to_own' : 'short_term';
+}
 
 /**
  * Converts a LeaseStatus to a ValidationLeaseStatus


### PR DESCRIPTION
## Summary
- default to proper `agreement_type`
- support template selection when creating agreements
- add agreement template API hook
- enforce status transitions in `useAgreementStatus`
- expose template and type fields via services and schema

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting an agreement template when creating or editing an agreement, with templates dynamically loaded from available options.
- **Enhancements**
  - Agreement type selection is now limited to "Short Term" and "Lease to Own" for greater clarity and consistency.
  - Improved validation and stricter control over allowed agreement status transitions.
- **Bug Fixes**
  - Default agreement type is now set to "Short Term" where previously it was "Lease" or "Rental".
- **Other**
  - Updated agreement-related forms and data structures to support the new agreement type and template selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR finalizes the lease agreement workflow by standardizing agreement types ('short_term' and 'lease_to_own') and adding template selection functionality. It updates UI components, validation schemas, service logic, and enhances status transition checks to prevent invalid state changes, creating a more robust agreement creation and editing process.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 3
</div>