### PR TITLE
Improve payment validation and dashboard updates

### DIFF
--- a/src/hooks/payment/use-payment-calculation.ts
+++ b/src/hooks/payment/use-payment-calculation.ts
@@ -19,10 +19,15 @@ export const usePaymentCalculation = (payments: Payment[], contractAmount: numbe
     
     // Sum up all payment amounts and paid amounts
     payments.forEach(payment => {
+      // Skip cancelled or voided payments entirely
+      if (payment.status === 'cancelled' || payment.status === 'voided') {
+        return;
+      }
+
       // Only count rent/income type payments for totals
       if (payment.type === 'rent' || payment.type === 'Income') {
         total += payment.amount || 0;
-        paid += payment.amount_paid || 0;
+        paid += payment.amount_paid ?? payment.amount ?? 0;
       }
       
       // Sum up late fees separately
@@ -61,7 +66,7 @@ export const usePaymentCalculation = (payments: Payment[], contractAmount: numbe
         } else {
           onTime++;
         }
-      } else if (payment.status === 'pending' || payment.status === 'overdue') {
+      } else if (payment.status === 'pending' || payment.status === 'overdue' || payment.status === 'partially_paid') {
         pending++;
       }
     });
@@ -70,7 +75,7 @@ export const usePaymentCalculation = (payments: Payment[], contractAmount: numbe
       paidOnTime: onTime,
       paidLate: late,
       unpaid: pending,
-      totalPayments: payments.length
+      totalPayments: payments.filter(p => p.status !== 'cancelled' && p.status !== 'voided').length
     };
   }, [payments]);
 

--- a/src/hooks/use-dashboard.ts
+++ b/src/hooks/use-dashboard.ts
@@ -3,6 +3,8 @@ import { supabase } from '@/lib/supabase';
 import { handleApiError } from '@/hooks/use-api';
 import { VehicleStatus } from '@/types/vehicle';
 import { CacheManager, useCachedData } from '@/lib/cache-utils';
+import { eventBus } from '@/lib/event-bus';
+import { Events, PaymentRecordedPayload } from '@/events';
 
 export interface DashboardStats {
   vehicleStats: {
@@ -365,6 +367,18 @@ export function useDashboardData() {
     },
     staleTime: 3 * 60 * 1000,
   });
+
+  useEffect(() => {
+    const unsubscribe = eventBus.subscribe<PaymentRecordedPayload>(
+      Events.PaymentRecorded,
+      () => {
+        statsQuery.refetch();
+        revenueQuery.refetch();
+        activityQuery.refetch();
+      }
+    );
+    return () => unsubscribe();
+  }, [statsQuery, revenueQuery, activityQuery]);
 
   return {
     stats: statsQuery.data,

--- a/src/hooks/use-financials.ts
+++ b/src/hooks/use-financials.ts
@@ -1,5 +1,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
+import { eventBus } from '@/lib/event-bus';
+import { Events, PaymentRecordedPayload } from '@/events';
 import { useMutation } from '@tanstack/react-query';
 import { useToast } from './use-toast';
 import { useApiMutation, useApiQuery } from './use-api';
@@ -769,6 +771,18 @@ export function useFinancials() {
       }
     }
   );
+
+  useEffect(() => {
+    const unsubscribe = eventBus.subscribe<PaymentRecordedPayload>(
+      Events.PaymentRecorded,
+      () => {
+        refetchTransactions();
+        refetchSummary();
+        refetchExpenses();
+      }
+    );
+    return () => unsubscribe();
+  }, [refetchTransactions, refetchSummary, refetchExpenses]);
 
   return {
     transactions,

--- a/src/lib/validation-schemas/payment.ts
+++ b/src/lib/validation-schemas/payment.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { PaymentStatus } from '@/types/payment.types';
+
+export const paymentStatusEnum = z.enum([
+  'pending',
+  'completed',
+  'overdue',
+  'cancelled',
+  'partially_paid',
+  'voided',
+  'failed',
+  'refunded'
+]);
+
+export const paymentSchema = z.object({
+  lease_id: z.string().min(1, 'Agreement is required'),
+  amount: z.number().positive('Amount must be positive'),
+  amount_paid: z.number().nonnegative().optional(),
+  balance: z.number().nonnegative().optional(),
+  payment_date: z.string().or(z.date()).optional(),
+  due_date: z.string().or(z.date()).optional(),
+  status: paymentStatusEnum.default('completed'),
+  payment_method: z.string().min(1).optional(),
+  description: z.string().optional(),
+  type: z.string().optional(),
+  late_fine_amount: z.number().nonnegative().optional(),
+  days_overdue: z.number().nonnegative().optional(),
+  original_due_date: z.string().or(z.date()).optional(),
+  reference_number: z.string().optional()
+});
+
+export type PaymentSchemaType = z.infer<typeof paymentSchema>;

--- a/src/services/PaymentService.ts
+++ b/src/services/PaymentService.ts
@@ -5,6 +5,7 @@ import { Events, PaymentRecordedPayload } from '@/events';
 import { castDbId } from '@/utils/supabase-type-helpers';
 import { BaseService } from './base/BaseService';
 import { Payment, PaymentInsert, SpecialPaymentOptions } from '@/types/payment.types';
+import { paymentSchema } from '@/lib/validation-schemas/payment';
 import { ServiceResponse } from '@/types/service.types';
 
 export class PaymentService extends BaseService {
@@ -13,9 +14,14 @@ export class PaymentService extends BaseService {
    */
   async recordPayment(paymentData: PaymentInsert): Promise<ServiceResponse<Payment>> {
     try {
+      const parsed = paymentSchema.safeParse(paymentData);
+      if (!parsed.success) {
+        return this.handleError(parsed.error, 'Invalid payment data');
+      }
+
       const { data, error } = await supabase
         .from('unified_payments')
-        .insert(paymentData)
+        .insert(parsed.data)
         .select()
         .single();
       
@@ -160,11 +166,16 @@ export class PaymentService extends BaseService {
         late_fine_amount: lateFineAmount,
         original_due_date: new Date(paymentDate.getFullYear(), paymentDate.getMonth(), 1).toISOString()
       };
+
+      const parsedPayment = paymentSchema.safeParse(paymentData);
+      if (!parsedPayment.success) {
+        return this.handleError(parsedPayment.error, 'Invalid payment data');
+      }
       
       // Record the payment
       const { data, error } = await supabase
         .from('unified_payments')
-        .insert([paymentData])
+        .insert([parsedPayment.data])
         .select()
         .single();
       
@@ -189,10 +200,13 @@ export class PaymentService extends BaseService {
           late_fine_amount: lateFineAmount,
           original_due_date: new Date(paymentDate.getFullYear(), paymentDate.getMonth(), 1).toISOString()
         };
-        
-        await supabase
-          .from('unified_payments')
-          .insert([lateFeePayment]);
+
+        const parsedLateFee = paymentSchema.safeParse(lateFeePayment);
+        if (parsedLateFee.success) {
+          await supabase
+            .from('unified_payments')
+            .insert([parsedLateFee.data]);
+        }
       }
       
       return this.success(data);

--- a/src/types/database-common.ts
+++ b/src/types/database-common.ts
@@ -1,5 +1,6 @@
 
 import { Database } from '@/types/database.types';
+import { PaymentStatus as PaymentStatusUnion } from '@/types/payment.types';
 export { isSuccessResponse } from '@/lib/database/validation/typeGuards';
 
 // Core database types with consistent naming
@@ -20,7 +21,7 @@ export type AgreementId = LeaseId; // Maintaining legacy compatibility
 // Standardized status types from database schema
 export type LeaseStatus = DatabaseTables['leases']['Row']['status'];
 export type VehicleStatus = DatabaseTables['vehicles']['Row']['status'];
-export type PaymentStatus = string; // Using string since it could have different values
+export type PaymentStatus = PaymentStatusUnion;
 export type ProfileStatus = string;
 export type MaintenanceStatus = string;
 

--- a/src/types/payment-types.unified.ts
+++ b/src/types/payment-types.unified.ts
@@ -9,13 +9,15 @@ export type PaymentUpdate = Database['public']['Tables']['unified_payments']['Up
 /**
  * Unified payment status types for the entire application
  */
-export type PaymentStatus = 
+export type PaymentStatus =
   | 'pending'
   | 'completed'
   | 'partially_paid'
   | 'overdue'
   | 'cancelled'
-  | 'voided';
+  | 'voided'
+  | 'failed'
+  | 'refunded';
 
 /**
  * Unified payment type for the entire application

--- a/src/types/payment.types.ts
+++ b/src/types/payment.types.ts
@@ -15,7 +15,9 @@ export type PaymentStatus =
   | 'overdue'
   | 'cancelled'
   | 'partially_paid'
-  | 'voided';
+  | 'voided'
+  | 'failed'
+  | 'refunded';
 
 export interface Payment {
   id: string;


### PR DESCRIPTION
## Summary
- add Zod validation schema for payments
- validate data in PaymentService before inserting
- update payment calculation logic to ignore voided and cancelled items
- refetch financial data when payments are recorded
- expand payment status types and fix casting

## Testing
- `npx tsc -p tsconfig.json --noEmit`