### PR TITLE
Integrate maintenance with agreements and providers

### DIFF
--- a/Vehicle_Maintenance.md
+++ b/Vehicle_Maintenance.md
@@ -11,12 +11,14 @@ The Vehicle Maintenance system manages scheduled and unscheduled maintenance for
 - `maintenance_categories`: Categorizes different types of maintenance
 - `maintenance_tasks`: Specific maintenance tasks assigned to vehicles
 - `maintenance_documents`: Documents related to maintenance (receipts, reports)
+- `maintenance_service_providers`: Directory of external maintenance providers
 - `parts_inventory`: Inventory of vehicle parts
 - `vehicle_parts`: Parts associated with specific vehicles/maintenance records
 - `vehicle_inspections`: Pre/post-rental inspections that may trigger maintenance
 
 ### Key Relationships
 - Maintenance records are linked to vehicles via `vehicle_id`
+- Maintenance records can reference rental agreements via `agreement_id`
 - Maintenance records may be associated with categories
 - Maintenance may be linked to specific parts from inventory
 - Inspections may trigger maintenance tasks
@@ -160,6 +162,11 @@ Maintenance directly relates to vehicle records, updating:
 - Maintenance scheduling impacts vehicle availability
 - Coordinates with rental schedule to minimize disruption
 - Sends notifications to relevant staff
+
+### 5. Service Provider Management
+- Providers are stored in `maintenance_service_providers`
+- Active providers can be selected on maintenance forms
+- Provider records include contact details and activity status
 
 ## Maintenance Predictions
 

--- a/docs/service-boundaries.md
+++ b/docs/service-boundaries.md
@@ -10,6 +10,8 @@ The monolith currently organizes domain logic under `src/services`. Each file ex
 - **VehicleService** – fleet information and maintenance history
 - **AgreementService** – rental agreements and lifecycle actions
 - **PaymentService** – payment processing and billing
+- **MaintenanceService** – maintenance records and cost tracking
+- **MaintenanceProviderService** – management of external service providers
 
 While they live in a single repository, treat each service as an independent boundary with its own database tables and types. Avoid cross‑service data access and share data only through well-defined interfaces.
 

--- a/src/components/maintenance/MaintenanceForm.tsx
+++ b/src/components/maintenance/MaintenanceForm.tsx
@@ -29,6 +29,7 @@ const MaintenanceForm: React.FC<MaintenanceFormProps> = ({
     defaultValues: {
       ...initialData || {
         vehicle_id: '',
+        agreement_id: '',
         service_type: '',
         maintenance_type: MaintenanceType.REGULAR_INSPECTION,
         status: MaintenanceStatus.SCHEDULED,
@@ -50,6 +51,9 @@ const MaintenanceForm: React.FC<MaintenanceFormProps> = ({
 
     if (initialData.category_id) {
       form.setValue('category_id', initialData.category_id);
+    }
+    if (initialData.agreement_id) {
+      form.setValue('agreement_id', initialData.agreement_id);
     }
     if (initialData.maintenance_type) {
       form.setValue('maintenance_type', initialData.maintenance_type);
@@ -97,6 +101,20 @@ const MaintenanceForm: React.FC<MaintenanceFormProps> = ({
                 <FormLabel>Vehicle ID</FormLabel>
                 <FormControl>
                   <Input placeholder="Vehicle ID" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="agreement_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Agreement ID</FormLabel>
+                <FormControl>
+                  <Input placeholder="Agreement ID" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/src/hooks/use-maintenance.ts
+++ b/src/hooks/use-maintenance.ts
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
+import { maintenanceService } from '@/services/MaintenanceService';
 import { useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { asMaintenanceId, asVehicleId, isQueryDataValid } from '@/utils/database-type-helpers';
@@ -10,6 +11,7 @@ import { asMaintenanceId, asVehicleId, isQueryDataValid } from '@/utils/database
 export type MaintenanceRecord = {
   id: string;
   vehicle_id: string;
+  agreement_id?: string;
   service_type: string;
   maintenance_type?: string;
   status: string;
@@ -82,20 +84,11 @@ export function useMaintenance() {
   const createMaintenanceRecord = async (record: MaintenanceRecord) => {
     setLoading(true);
     try {
-      const { data, error } = await supabase
-        .from('maintenance')
-        .insert(record)
-        .select()
-        .single();
-
-      // Some Supabase clients may return both data and error even when the
-      // insert succeeds. Treat it as success if a record was returned.
-      if (error && !data) throw error;
-
+      const result = await maintenanceService.createMaintenance(record as any);
+      if (!result.success) throw result.error;
       await queryClient.invalidateQueries({ queryKey: ['maintenance'] });
-
       toast.success('Maintenance record created successfully');
-      return data;
+      return result.data;
     } catch (error) {
       console.error('Error creating maintenance record:', error);
       // Only notify the user if the insert truly failed
@@ -110,20 +103,11 @@ export function useMaintenance() {
   const updateMaintenanceRecord = async (maintenanceId: string, updates: Partial<MaintenanceRecord>) => {
     setLoading(true);
     try {
-      const { data, error } = await supabase
-        .from('maintenance')
-        .update(updates)
-        .eq('id', asMaintenanceId(maintenanceId))
-        .select()
-        .single();
-
-      if (error) throw error;
-      
-      // Invalidate and refetch
+      const result = await maintenanceService.updateMaintenance(maintenanceId, updates as any);
+      if (!result.success) throw result.error;
       await queryClient.invalidateQueries({ queryKey: ['maintenance'] });
-      
       toast.success('Maintenance record updated successfully');
-      return data;
+      return result.data;
     } catch (error) {
       console.error('Error updating maintenance record:', error);
       toast.error('Failed to update maintenance record');

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -4944,6 +4944,7 @@ export type Database = {
           service_type: string
           status: Database["public"]["Enums"]["maintenance_status"] | null
           updated_at: string
+          agreement_id: string | null
           vehicle_id: string
         }
         Insert: {
@@ -4960,6 +4961,7 @@ export type Database = {
           service_type: string
           status?: Database["public"]["Enums"]["maintenance_status"] | null
           updated_at?: string
+          agreement_id?: string | null
           vehicle_id: string
         }
         Update: {
@@ -4976,6 +4978,7 @@ export type Database = {
           service_type?: string
           status?: Database["public"]["Enums"]["maintenance_status"] | null
           updated_at?: string
+          agreement_id?: string | null
           vehicle_id?: string
         }
         Relationships: [
@@ -4991,6 +4994,20 @@ export type Database = {
             columns: ["vehicle_id"]
             isOneToOne: false
             referencedRelation: "vehicles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "maintenance_agreement_id_fkey"
+            columns: ["agreement_id"]
+            isOneToOne: false
+            referencedRelation: "leases"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "maintenance_agreement_id_fkey"
+            columns: ["agreement_id"]
+            isOneToOne: false
+            referencedRelation: "leases_missing_payments"
             referencedColumns: ["id"]
           },
         ]
@@ -5174,6 +5191,42 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      maintenance_service_providers: {
+        Row: {
+          id: string
+          name: string
+          contact_info: string | null
+          phone: string | null
+          email: string | null
+          address: string | null
+          is_active: boolean | null
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: string
+          name: string
+          contact_info?: string | null
+          phone?: string | null
+          email?: string | null
+          address?: string | null
+          is_active?: boolean | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: string
+          name?: string
+          contact_info?: string | null
+          phone?: string | null
+          email?: string | null
+          address?: string | null
+          is_active?: boolean | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
       }
       master_sheet_data: {
         Row: {

--- a/src/lib/database/index.ts
+++ b/src/lib/database/index.ts
@@ -11,12 +11,16 @@ import { createLeaseRepository } from './repositories/lease-repository';
 import { createPaymentRepository } from './repositories/payment-repository';
 import { createVehicleRepository } from './repositories/vehicle-repository';
 import { createProfileRepository } from './repositories/profile-repository';
+import { createMaintenanceRepository } from './repositories/maintenance-repository';
+import { createMaintenanceProviderRepository } from './repositories/maintenance-provider-repository';
 
 // Create repositories using the supabase client
 export const leaseRepository = createLeaseRepository(supabase);
 export const paymentRepository = createPaymentRepository(supabase);
 export const vehicleRepository = createVehicleRepository(supabase);
 export const profileRepository = createProfileRepository(supabase);
+export const maintenanceRepository = createMaintenanceRepository(supabase);
+export const maintenanceProviderRepository = createMaintenanceProviderRepository(supabase);
 
 // Re-export utils and validation
 export { utils, validation, typeGuards };
@@ -29,6 +33,8 @@ export { leaseRepository as leaseRepo };
 export { paymentRepository as paymentRepo };
 export { vehicleRepository as vehicleRepo };
 export { profileRepository as profileRepo };
+export { maintenanceRepository as maintenanceRepo };
+export { maintenanceProviderRepository as maintenanceProviderRepo };
 
 // Export common utility functions for database responses
 export { isSuccessResponse } from './validation/typeGuards';

--- a/src/lib/database/repositories/maintenance-provider-repository.ts
+++ b/src/lib/database/repositories/maintenance-provider-repository.ts
@@ -1,0 +1,14 @@
+import { Repository } from '../repository';
+import { Tables, TableRow } from '../types';
+import { supabase } from '@/lib/supabase';
+
+export type MaintenanceProviderRow = TableRow<'maintenance_service_providers'>;
+
+export class MaintenanceProviderRepository extends Repository<'maintenance_service_providers'> {
+  constructor(client: any) {
+    super(client, 'maintenance_service_providers');
+  }
+}
+
+export const maintenanceProviderRepository = new MaintenanceProviderRepository(supabase);
+export const createMaintenanceProviderRepository = (client: any) => new MaintenanceProviderRepository(client);

--- a/src/lib/database/repositories/maintenance-repository.ts
+++ b/src/lib/database/repositories/maintenance-repository.ts
@@ -1,0 +1,24 @@
+import { Repository } from '../repository';
+import { Tables, TableRow, DbListResponse } from '../types';
+import { asMaintenanceId } from '../database-types';
+import { supabase } from '@/lib/supabase';
+
+export type MaintenanceRow = TableRow<'maintenance'>;
+
+export class MaintenanceRepository extends Repository<'maintenance'> {
+  constructor(client: any) {
+    super(client, 'maintenance');
+  }
+
+  async findByVehicle(vehicleId: string): Promise<DbListResponse<MaintenanceRow>> {
+    const response = await this.client
+      .from('maintenance')
+      .select('*')
+      .eq('vehicle_id', vehicleId)
+      .order('scheduled_date', { ascending: false });
+    return { data: response.data, error: response.error };
+  }
+}
+
+export const maintenanceRepository = new MaintenanceRepository(supabase);
+export const createMaintenanceRepository = (client: any) => new MaintenanceRepository(client);

--- a/src/lib/validation-schemas/maintenance.ts
+++ b/src/lib/validation-schemas/maintenance.ts
@@ -39,6 +39,7 @@ export const VehicleRefSchema = z.object({
 export const maintenanceSchema = z.object({
   id: z.string().optional(),
   vehicle_id: z.string().min(1, "Vehicle is required"),
+  agreement_id: z.string().optional(),
   maintenance_type: z.enum([
     MaintenanceType.OIL_CHANGE,
     MaintenanceType.TIRE_REPLACEMENT,
@@ -87,6 +88,7 @@ export type MaintenanceFilters = Partial<{
 // Helper for creating a new maintenance record
 export const createEmptyMaintenance = (): Omit<Maintenance, "id"> => ({
   vehicle_id: "",
+  agreement_id: "",
   maintenance_type: MaintenanceType.REGULAR_INSPECTION,
   status: MaintenanceStatus.SCHEDULED,
   scheduled_date: new Date(),

--- a/src/pages/AddMaintenance.tsx
+++ b/src/pages/AddMaintenance.tsx
@@ -13,6 +13,7 @@ const AddMaintenance = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const prefilledVehicleId = searchParams.get('vehicle_id') || '';
+  const prefilledAgreementId = searchParams.get('agreement_id') || '';
   const { create } = useMaintenance();
   const { toast } = useToast();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -50,6 +51,7 @@ const AddMaintenance = () => {
         status: validateMaintenanceStatus(formData.status || MaintenanceStatus.SCHEDULED),
         // Ensure vehicle_id is never empty
         vehicle_id: formData.vehicle_id || null,
+        agreement_id: formData.agreement_id || null,
         // Ensure cost is a number
         cost: typeof formData.cost === 'number' ? formData.cost : parseFloat(formData.cost) || 0,
       };
@@ -89,7 +91,7 @@ const AddMaintenance = () => {
       <MaintenanceForm
         onSubmit={handleSubmit}
         isLoading={isSubmitting}
-        initialData={{ vehicle_id: prefilledVehicleId }}
+        initialData={{ vehicle_id: prefilledVehicleId, agreement_id: prefilledAgreementId }}
       />
     </PageContainer>
   );

--- a/src/services/MaintenanceProviderService.ts
+++ b/src/services/MaintenanceProviderService.ts
@@ -1,0 +1,23 @@
+import { maintenanceProviderRepository } from '@/lib/database';
+import { TableRow } from '@/lib/database/types';
+import { BaseService, handleServiceOperation, ServiceResult } from './base/BaseService';
+
+export type MaintenanceProvider = TableRow<'maintenance_service_providers'>;
+
+export class MaintenanceProviderService extends BaseService<'maintenance_service_providers'> {
+  constructor() {
+    super(maintenanceProviderRepository);
+  }
+
+  async findActive(): Promise<ServiceResult<MaintenanceProvider[]>> {
+    return handleServiceOperation(async () => {
+      const result = await this.repository.findByField('is_active', true);
+      if (result.error) {
+        throw new Error(`Failed to fetch active providers: ${result.error.message}`);
+      }
+      return result.data || [];
+    });
+  }
+}
+
+export const maintenanceProviderService = new MaintenanceProviderService();

--- a/src/services/MaintenanceService.ts
+++ b/src/services/MaintenanceService.ts
@@ -1,0 +1,52 @@
+import { maintenanceRepository } from '@/lib/database';
+import { TableRow } from '@/lib/database/types';
+import { BaseService, handleServiceOperation, ServiceResult } from './base/BaseService';
+import { paymentService } from './PaymentService';
+
+export type Maintenance = TableRow<'maintenance'>;
+
+export class MaintenanceService extends BaseService<'maintenance'> {
+  constructor() {
+    super(maintenanceRepository);
+  }
+
+  async createMaintenance(data: Maintenance): Promise<ServiceResult<Maintenance>> {
+    return handleServiceOperation(async () => {
+      const result = await this.repository.create(data);
+      if (result.error || !result.data) {
+        throw new Error(result.error?.message || 'Failed to create maintenance');
+      }
+      if (result.data.cost && result.data.status === 'completed') {
+        await this.recordExpense(result.data);
+      }
+      return result.data;
+    });
+  }
+
+  async updateMaintenance(id: string, data: Partial<Maintenance>): Promise<ServiceResult<Maintenance>> {
+    return handleServiceOperation(async () => {
+      const result = await this.repository.update(id, data);
+      if (result.error || !result.data) {
+        throw new Error(result.error?.message || 'Failed to update maintenance');
+      }
+      if (result.data.cost && result.data.status === 'completed') {
+        await this.recordExpense(result.data);
+      }
+      return result.data;
+    });
+  }
+
+  private async recordExpense(record: Maintenance) {
+    await paymentService.recordPayment({
+      lease_id: record.agreement_id ?? null,
+      amount: record.cost ?? 0,
+      payment_date: new Date().toISOString(),
+      description: `Maintenance expense for vehicle ${record.vehicle_id}`,
+      status: 'completed',
+      type: 'Expense',
+      payment_method: 'internal'
+    } as any);
+  }
+}
+
+export const maintenanceService = new MaintenanceService();

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -5,3 +5,5 @@ export * from './CustomerService';
 export * from './PaymentService';
 export * from './base/BaseService';
 export * from './UserService';
+export * from './MaintenanceService';
+export * from './MaintenanceProviderService';


### PR DESCRIPTION
## Summary
- link maintenance records to agreements and vehicles
- track maintenance costs as expenses via MaintenanceService
- manage service providers through new MaintenanceProviderService
- expose new services in index exports
- update maintenance forms and pages for agreement ID
- document provider management and new service boundaries

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run check-boundaries`