### PR TITLE
Implement remaining amount function and unify payment data

### DIFF
--- a/src/hooks/use-car-installments.ts
+++ b/src/hooks/use-car-installments.ts
@@ -199,6 +199,17 @@ export const useCarInstallments = () => {
         .from('car_installment_payments')
         .insert([newPayment])
         .select();
+
+      if (!error && data && data[0]) {
+        await supabase.from('unified_payments').insert({
+          amount: newPayment.amount ?? 0,
+          amount_paid: newPayment.paid_amount ?? newPayment.amount ?? 0,
+          payment_date: newPayment.payment_date,
+          description: 'Car Installment Payment',
+          type: 'Expense',
+          status: newPayment.status
+        });
+      }
         
       if (error) throw error;
       return data[0];

--- a/src/hooks/use-financials.ts
+++ b/src/hooks/use-financials.ts
@@ -95,7 +95,7 @@ export function useFinancials() {
         }
 
         const { data: installmentData, error: installmentError } = await supabase
-          .from('car_installments')
+          .from('car_installment_payments')
           .select('*');
 
         if (installmentError) {
@@ -493,15 +493,13 @@ export function useFinancials() {
       if (typeof id === 'string' && id.startsWith('inst-')) {
         const actualId = id.replace('inst-', '');
         const { data: updatedData, error } = await supabase
-          .from('car_installments')
+          .from('car_installment_payments')
           .update({
-            payment_amount: data.amount,
+            amount: data.amount,
             payment_date: data.date?.toISOString(),
-            payment_status: data.status,
-            vehicle_description: data.description,
-            payment_method: data.paymentMethod,
-            reference: data.reference,
-            vehicle_id: data.vehicleId
+            status: data.status,
+            payment_notes: data.description,
+            payment_reference: data.reference
           })
           .eq('id', actualId)
           .select()
@@ -515,14 +513,12 @@ export function useFinancials() {
         return {
           id: `inst-${updatedData.id}`,
           date: new Date(updatedData.payment_date),
-          amount: updatedData.payment_amount,
-          description: updatedData.vehicle_description,
+          amount: updatedData.amount,
+          description: updatedData.payment_notes ?? 'Installment Payment',
           type: 'expense',
           category: 'Installment',
-          status: updatedData.payment_status as TransactionStatusType,
-          reference: updatedData.reference,
-          paymentMethod: updatedData.payment_method,
-          vehicleId: updatedData.vehicle_id
+          status: updatedData.status as TransactionStatusType,
+          reference: updatedData.payment_reference,
         };
       } else {
         const { data: updatedData, error } = await supabase
@@ -585,7 +581,7 @@ export function useFinancials() {
       if (typeof id === 'string' && id.startsWith('inst-')) {
         const actualId = id.replace('inst-', '');
         const { error } = await supabase
-          .from('car_installments')
+          .from('car_installment_payments')
           .delete()
           .eq('id', actualId);
 

--- a/src/services/AgreementService.ts
+++ b/src/services/AgreementService.ts
@@ -357,7 +357,7 @@ export const agreementService = {
     try {
       // This is a placeholder implementation - in reality you would need to implement this
       // based on your business logic and database structure
-      const { data, error } = await supabase.rpc('calculate_remaining_amount', { agreement_id: id });
+      const { data, error } = await supabase.rpc('calculate_remaining_amount', { lease_id: id });
       
       if (error) throw error;
       

--- a/supabase/migrations/20250518_create_calculate_remaining_amount_function.sql
+++ b/supabase/migrations/20250518_create_calculate_remaining_amount_function.sql
@@ -1,0 +1,25 @@
+-- Calculate remaining amount for a lease
+CREATE OR REPLACE FUNCTION public.calculate_remaining_amount(lease_id UUID)
+RETURNS numeric
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  total_amount numeric;
+  total_paid numeric;
+BEGIN
+  -- Get total amount from the lease
+  SELECT COALESCE(total_amount, 0)
+  INTO total_amount
+  FROM leases
+  WHERE id = lease_id;
+
+  -- Sum of all payments recorded for the lease
+  SELECT COALESCE(SUM(COALESCE(amount_paid, amount)), 0)
+  INTO total_paid
+  FROM unified_payments up
+  WHERE up.lease_id = lease_id
+    AND status IS DISTINCT FROM 'voided';
+
+  RETURN COALESCE(total_amount, 0) - COALESCE(total_paid, 0);
+END;
+$$;


### PR DESCRIPTION
## Summary
- add SQL function `calculate_remaining_amount`
- fix AgreementService to call function with `lease_id`
- include car installment payments in unified financial reports
- keep unified payment record when saving car installment payments

## Testing
- `npm run lint` *(fails: cannot find package)*
- `npm run build` *(fails: vite not found)*