### PR TITLE
Add Field Operations PWA

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="manifest" href="/manifest.json" />
     <title>Fleet Management System</title>
     <!-- Lovable script tag -->
     <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
@@ -12,5 +13,12 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js');
+        });
+      }
+    </script>
   </body>
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "Field Operations",
+  "short_name": "FieldOps",
+  "start_url": "/field-ops",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0a8754",
+  "icons": [
+    { "src": "/favicon.ico", "sizes": "64x64 32x32 24x24 16x16", "type": "image/x-icon" }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,25 @@
+const CACHE_NAME = 'field-ops-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+];
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((names) =>
+      Promise.all(names.filter((n) => n !== CACHE_NAME).map((n) => caches.delete(n)))
+    )
+  );
+});
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(request).then((cached) => cached || fetch(request))
+  );
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,11 @@ import ScheduledReports from "./pages/ScheduledReports";
 // System Settings pages
 import SystemSettings from "./pages/SystemSettings";
 
+// Mobile Field Operations pages
+import FieldOperations from "./pages/mobile/FieldOperations";
+import QRScanPage from "./pages/mobile/QRScanPage";
+import VehicleInspectionPage from "./pages/mobile/VehicleInspectionPage";
+
 import initializeApp from "./utils/app-initializer";
 
 function App() {
@@ -120,6 +125,11 @@ function App() {
                       element={
                         <ProtectedRoute>
                           <>
+                            <Routes>
+                              <Route path="/field-ops" element={<FieldOperations />} />
+                              <Route path="/field-ops/scan" element={<QRScanPage />} />
+                              <Route path="/field-ops/inspection/:vehicleId" element={<VehicleInspectionPage />} />
+                            </Routes>
                             <Sidebar />
                             <Routes>
                               <Route path="/dashboard" element={<Dashboard />} />

--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -12,7 +12,7 @@ export function MobileDashboard() {
     { 
       name: 'Start Vehicle Inspection', 
       icon: Car, 
-      route: '/inspection',
+      route: '/field-ops/inspection',
       primary: true,
       description: 'Perform digital vehicle inspection with photos'
     },
@@ -53,7 +53,7 @@ export function MobileDashboard() {
         ))}
       </div>
       
-      <Button className="w-full mt-4" variant="outline">
+      <Button className="w-full mt-4" variant="outline" onClick={() => navigate('/field-ops/scan')}>
         Scan Vehicle QR Code
       </Button>
     </div>

--- a/src/components/mobile/VehicleInspection.tsx
+++ b/src/components/mobile/VehicleInspection.tsx
@@ -28,6 +28,16 @@ export function VehicleInspection({ vehicle }: { vehicle: Vehicle }) {
     { name: 'Brakes', status: 'pending', notes: '', photos: [] },
     { name: 'Dashboard Warning Lights', status: 'pending', notes: '', photos: [] }
   ]);
+  const [location, setLocation] = useState<{ lat: number; lon: number } | null>(null);
+
+  useEffect(() => {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => setLocation({ lat: pos.coords.latitude, lon: pos.coords.longitude }),
+        () => {}
+      );
+    }
+  }, []);
 
   const handlePhotoCapture = async (itemIndex: number) => {
     try {
@@ -76,6 +86,27 @@ export function VehicleInspection({ vehicle }: { vehicle: Vehicle }) {
     setInspectionItems(updatedItems);
   };
 
+  const savePendingInspection = (data: any) => {
+    const existing = JSON.parse(localStorage.getItem('pendingInspections') || '[]');
+    existing.push(data);
+    localStorage.setItem('pendingInspections', JSON.stringify(existing));
+  };
+
+  useEffect(() => {
+    const syncPending = async () => {
+      if (!navigator.onLine) return;
+      const pending = JSON.parse(localStorage.getItem('pendingInspections') || '[]');
+      if (!pending.length) return;
+      for (const item of pending) {
+        await supabase.from('vehicle_inspections').insert(item);
+      }
+      localStorage.removeItem('pendingInspections');
+    };
+    window.addEventListener('online', syncPending);
+    syncPending();
+    return () => window.removeEventListener('online', syncPending);
+  }, []);
+
   const handleSubmitInspection = async () => {
     setIsSubmitting(true);
     try {
@@ -85,7 +116,8 @@ export function VehicleInspection({ vehicle }: { vehicle: Vehicle }) {
         inspection_items: inspectionItems,
         status: inspectionItems.every(item => item.status === 'pass') ? 'passed' : 'failed',
         inspector_notes: inspectionItems.map(item => item.notes).filter(Boolean).join('\n'),
-        inspection_photos: inspectionItems.flatMap(item => item.photos)
+        inspection_photos: inspectionItems.flatMap(item => item.photos),
+        location
       };
 
       const { error } = await supabase
@@ -93,11 +125,20 @@ export function VehicleInspection({ vehicle }: { vehicle: Vehicle }) {
         .insert([inspection]);
 
       if (error) throw error;
-      
+
       toast.success('Inspection submitted successfully');
     } catch (error) {
       console.error('Failed to submit inspection:', error);
-      toast.error('Failed to submit inspection');
+      savePendingInspection({
+        vehicle_id: vehicle.id,
+        inspection_date: new Date().toISOString(),
+        inspection_items: inspectionItems,
+        status: inspectionItems.every(item => item.status === 'pass') ? 'passed' : 'failed',
+        inspector_notes: inspectionItems.map(item => item.notes).filter(Boolean).join('\n'),
+        inspection_photos: inspectionItems.flatMap(item => item.photos),
+        location
+      });
+      toast.error('Failed to submit inspection. Saved offline.');
     } finally {
       setIsSubmitting(false);
     }

--- a/src/pages/mobile/FieldOperations.tsx
+++ b/src/pages/mobile/FieldOperations.tsx
@@ -1,0 +1,5 @@
+import { MobileDashboard } from '@/components/mobile/MobileDashboard';
+
+export default function FieldOperations() {
+  return <MobileDashboard />;
+}

--- a/src/pages/mobile/QRScanPage.tsx
+++ b/src/pages/mobile/QRScanPage.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function QRScanPage() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    let stream: MediaStream | null = null;
+    const start = async () => {
+      if (!navigator.mediaDevices || !(window as any).BarcodeDetector) return;
+      const detector = new (window as any).BarcodeDetector({ formats: ['qr_code'] });
+      stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play();
+        const scan = async () => {
+          if (!videoRef.current) return;
+          try {
+            const codes = await detector.detect(videoRef.current);
+            if (codes.length > 0) {
+              navigate(`/field-ops/inspection/${encodeURIComponent(codes[0].rawValue)}`);
+              return;
+            }
+          } catch {}
+          requestAnimationFrame(scan);
+        };
+        scan();
+      }
+    };
+    start();
+    return () => {
+      if (stream) stream.getTracks().forEach((t) => t.stop());
+    };
+  }, [navigate]);
+
+  return (
+    <div className="p-4 space-y-2">
+      <h1 className="text-xl font-bold">Scan Vehicle QR Code</h1>
+      <video ref={videoRef} className="w-full h-auto" />
+    </div>
+  );
+}

--- a/src/pages/mobile/VehicleInspectionPage.tsx
+++ b/src/pages/mobile/VehicleInspectionPage.tsx
@@ -1,0 +1,13 @@
+import { useParams } from 'react-router-dom';
+import { useVehicleDetail } from '@/hooks/use-vehicle-detail';
+import { VehicleInspection } from '@/components/mobile/VehicleInspection';
+
+export default function VehicleInspectionPage() {
+  const { vehicleId } = useParams<{ vehicleId: string }>();
+  const { vehicle, isLoading } = useVehicleDetail(vehicleId);
+
+  if (isLoading) return <p className="p-4">Loading...</p>;
+  if (!vehicle) return <p className="p-4">Vehicle not found</p>;
+
+  return <VehicleInspection vehicle={vehicle} />;
+}


### PR DESCRIPTION
## Summary
- add PWA manifest and simple service worker
- register service worker in `index.html`
- add Field Operations mobile pages with QR scanning and vehicle inspection
- capture GPS location and queue inspections offline until back online
- add routes for the PWA in `App.tsx`

## Testing
- `npm run check-boundaries`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*