### PR TITLE
Fix maintenance hook exports

### DIFF
--- a/src/hooks/use-maintenance.ts
+++ b/src/hooks/use-maintenance.ts
@@ -239,8 +239,9 @@ export function useMaintenance() {
     });
   };
 
-  // Create function for MaintenanceSchedulingWizard
+  // Convenient mutation hooks
   const create = useCreateMaintenance();
+  const update = useUpdateMaintenance();
 
   return {
     loading,
@@ -259,6 +260,7 @@ export function useMaintenance() {
     useCreateMaintenance,
     useUpdateMaintenance,
     useDeleteMaintenance,
-    create
+    create,
+    update
   };
 }

--- a/src/pages/MaintenanceDetailPage.tsx
+++ b/src/pages/MaintenanceDetailPage.tsx
@@ -15,11 +15,11 @@ import { supabase } from '@/lib/supabase';
 const MaintenanceDetailPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { useOne, useDelete } = useMaintenance();
+  const { useMaintenanceDetails, useDeleteMaintenance } = useMaintenance();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
-  const { data: maintenance, isLoading, error } = useOne(id!);
-  const deleteMutation = useDelete;
+  const { data: maintenance, isLoading, error } = useMaintenanceDetails(id!);
+  const deleteMutation = useDeleteMaintenance();
 
   if (isLoading) {
     return (


### PR DESCRIPTION
## Summary
- expose `update` mutation from `useMaintenance`
- switch detail page to new hook names

## Testing
- `npx tsc --noEmit` *(fails: command not found)*