### PR TITLE
Fix TypeScript React imports

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -25,7 +25,7 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "types": []
+    "types": ["vite/client", "react", "react-dom"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- include React types in `tsconfig.app.json`

## Testing
- `npm install` *(fails: Exit handler never called)*
- `npx --yes tsc -p tsconfig.app.json` *(fails: cannot find modules)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved TypeScript support for Vite and React, enhancing type checking and editor IntelliSense.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->