### PR TITLE
Add type-check script and update migration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint": "eslint .",
     "check-boundaries": "node scripts/check-boundaries.cjs",
     "preview": "vite preview",
-    "send-scheduled-reports": "node scripts/send-scheduled-reports.js"
+    "send-scheduled-reports": "node scripts/send-scheduled-reports.js",
+    "type-check": "tsc --noEmit",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/scripts/test-migration.ps1
+++ b/scripts/test-migration.ps1
@@ -6,8 +6,9 @@ Write-Host "=== Service Migration Testing Script ===" -ForegroundColor Cyan
 Write-Host "This script will test the core functionality of migrated services" -ForegroundColor Cyan
 Write-Host ""
 
-# Navigate to project directory
-Set-Location "c:\Users\khamis\coodebase rental\rental-solutions-28bf4163"
+# The script assumes it is run from the project root. Remove any
+# hard-coded directory changes so it can be executed from the current
+# working directory.
 
 # Step 1: Run type checking to verify no type errors
 Write-Host "Step 1: Running TypeScript type checking..." -ForegroundColor Green


### PR DESCRIPTION
## Summary
- add `type-check` and example `test` scripts
- rely on current directory in the Powershell migration script

## Testing
- `npm run type-check`
- `npm run test` *(fails: vitest not found)*