### PR TITLE
Add basic vitest setup and traffic fines tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "check-boundaries": "node scripts/check-boundaries.cjs",
     "preview": "vite preview",
-    "send-scheduled-reports": "node scripts/send-scheduled-reports.js"
+    "send-scheduled-reports": "node scripts/send-scheduled-reports.js",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -92,6 +93,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^1.5.0"
   }
 }

--- a/tests/traffic-fines.test.ts
+++ b/tests/traffic-fines.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { runTrafficFinesSystemHealthCheck, testTrafficFineAssignment } from '@/utils/traffic-fines-test-utils';
+import { checkDatabaseHealth, runDatabaseDiagnostics } from '@/utils/database-health-check';
+
+describe('traffic fines utilities', () => {
+  it('runs system health check', async () => {
+    const result = await runTrafficFinesSystemHealthCheck();
+    expect(result).toHaveProperty('status');
+  });
+
+  it('tests traffic fine assignment', async () => {
+    const result = await testTrafficFineAssignment('test-id');
+    expect(result).toHaveProperty('success');
+  });
+
+  it('checks database health', async () => {
+    const result = await checkDatabaseHealth();
+    expect(result).toHaveProperty('isHealthy');
+  });
+
+  it('runs database diagnostics', async () => {
+    const result = await runDatabaseDiagnostics();
+    expect(result).toHaveProperty('isConnected');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,26 +1,35 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-    allowedHosts: [
-      "3443e083-f60b-43c2-aa17-354a2369068f.lovableproject.com",
-      "localhost"
-    ],
-  },
-  plugins: [
-    react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  Object.assign(process.env, env);
+
+  return {
+    server: {
+      host: "::",
+      port: 8080,
+      allowedHosts: [
+        "3443e083-f60b-43c2-aa17-354a2369068f.lovableproject.com",
+        "localhost"
+      ],
     },
-  },
-}));
+    plugins: [
+      react(),
+      mode === 'development' &&
+      componentTagger(),
+    ].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+    test: {
+      environment: "node",
+      globals: true,
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- configure vitest in vite config and package.json
- add new tests for traffic fines utilities and DB health

## Testing
- `npm test` *(fails: vitest not found)* 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request establishes a basic setup for Vitest, integrating it with the Vite configuration. It also adds tests for traffic fines utilities and database health checks, significantly enhancing the project's testing capabilities.
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a test suite for traffic fines utilities, including health checks and diagnostics.
- **Chores**
  - Added a new script to run tests and included Vitest as a development dependency.
  - Updated configuration to support testing with Vitest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->