### PR TITLE
Fix typing issues with React components

### DIFF
--- a/src/components/agreements/AgreementFilterPanel.tsx
+++ b/src/components/agreements/AgreementFilterPanel.tsx
@@ -28,16 +28,16 @@ interface AgreementFilterPanelProps {
 
 export function AgreementFilterPanel({ onFilterChange, currentFilters = {} }: AgreementFilterPanelProps) {
   const [agreementNumber, setAgreementNumber] = useState(currentFilters?.agreement_number || '');
-  const [startDateFrom, setStartDateFrom] = useState<Date | undefined>(
+  const [startDateFrom, setStartDateFrom] = useState(
     currentFilters?.start_date_after ? new Date(currentFilters.start_date_after) : undefined
   );
-  const [startDateTo, setStartDateTo] = useState<Date | undefined>(
+  const [startDateTo, setStartDateTo] = useState(
     currentFilters?.start_date_before ? new Date(currentFilters.start_date_before) : undefined
   );
-  const [endDateFrom, setEndDateFrom] = useState<Date | undefined>(
+  const [endDateFrom, setEndDateFrom] = useState(
     currentFilters?.end_date_after ? new Date(currentFilters.end_date_after) : undefined
   );
-  const [endDateTo, setEndDateTo] = useState<Date | undefined>(
+  const [endDateTo, setEndDateTo] = useState(
     currentFilters?.end_date_before ? new Date(currentFilters.end_date_before) : undefined
   );
   const [licensePlate, setLicensePlate] = useState(currentFilters?.license_plate || '');

--- a/src/components/agreements/AgreementFilters.tsx
+++ b/src/components/agreements/AgreementFilters.tsx
@@ -30,16 +30,16 @@ interface AgreementFiltersProps {
 export function AgreementFilters({ onFilterChange, currentFilters = {} }: AgreementFiltersProps) {
   const [agreementNumber, setAgreementNumber] = useState(currentFilters?.agreement_number || '');
   const [dateRange, setDateRange] = useState<'rental_period' | 'creation_date'>('rental_period');
-  const [startDateFrom, setStartDateFrom] = useState<Date | undefined>(
+  const [startDateFrom, setStartDateFrom] = useState(
     currentFilters?.start_date_after ? new Date(currentFilters.start_date_after) : undefined
   );
-  const [startDateTo, setStartDateTo] = useState<Date | undefined>(
+  const [startDateTo, setStartDateTo] = useState(
     currentFilters?.start_date_before ? new Date(currentFilters.start_date_before) : undefined
   );
-  const [endDateFrom, setEndDateFrom] = useState<Date | undefined>(
+  const [endDateFrom, setEndDateFrom] = useState(
     currentFilters?.end_date_after ? new Date(currentFilters.end_date_after) : undefined
   );
-  const [endDateTo, setEndDateTo] = useState<Date | undefined>(
+  const [endDateTo, setEndDateTo] = useState(
     currentFilters?.end_date_before ? new Date(currentFilters.end_date_before) : undefined
   );
   const [minRent, setMinRent] = useState(currentFilters?.rent_min || '');

--- a/src/components/agreements/AgreementForm.tsx
+++ b/src/components/agreements/AgreementForm.tsx
@@ -20,12 +20,12 @@ interface AgreementFormProps {
   validationErrors?: Record<string, string> | null;
 }
 
-const AgreementForm: React.FC<AgreementFormProps> = ({
+const AgreementForm = ({
   initialData,
   onSubmit,
   isSubmitting = false,
   validationErrors
-}) => {
+}: AgreementFormProps) => {
   const [termsAccepted, setTermsAccepted] = useState(initialData?.terms_accepted || false);
   const [selectedVehicle, setSelectedVehicle] = useState<any>(null);
   const [selectedCustomer, setSelectedCustomer] = useState<CustomerInfo | null>(null);

--- a/src/components/agreements/AgreementFormWithVehicleCheck.tsx
+++ b/src/components/agreements/AgreementFormWithVehicleCheck.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import type { FormEvent } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
@@ -70,7 +71,7 @@ const AgreementFormWithVehicleCheck = ({
     }
   ];
 
-  const handleSubmit = (event: React.FormEvent) => {
+  const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
     onSubmit(formData);
   };

--- a/src/components/agreements/AgreementList.tsx
+++ b/src/components/agreements/AgreementList.tsx
@@ -4,7 +4,7 @@ import { useAgreementService } from '@/hooks/services/useAgreementService';
 import { TableContent } from './table/TableContent';
 import { processAgreementData } from './table/agreement-data';
 
-const AgreementList: React.FC = () => {
+const AgreementList = () => {
   const {
     agreements,
     isLoading,

--- a/src/components/agreements/AgreementListFilter.tsx
+++ b/src/components/agreements/AgreementListFilter.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { Input } from "@/components/ui/input";
 import { Search, X, Filter } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -18,15 +19,15 @@ interface AgreementListFilterProps {
   onFilterChange?: (filters: Record<string, any>) => void;
 }
 
-export const AgreementListFilter: React.FC<AgreementListFilterProps> = ({
+export const AgreementListFilter = ({
   onSearch,
   searchTerm,
   onFilterChange
-}) => {
+}: AgreementListFilterProps) => {
   const [searchValue, setSearchValue] = useState(searchTerm);
   
   // Handle search input changes with direct debounce implementation
-  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setSearchValue(value);
     

--- a/src/components/agreements/AgreementLoadingState.tsx
+++ b/src/components/agreements/AgreementLoadingState.tsx
@@ -7,10 +7,10 @@ interface AgreementLoadingStateProps {
   hasAgreement: boolean;
 }
 
-export const AgreementLoadingState: React.FC<AgreementLoadingStateProps> = ({
+export const AgreementLoadingState = ({
   isLoading,
   hasAgreement
-}) => {
+}: AgreementLoadingStateProps) => {
   if (isLoading) {
     return (
       <div className="space-y-6">

--- a/src/components/agreements/AgreementSubmitHandler.tsx
+++ b/src/components/agreements/AgreementSubmitHandler.tsx
@@ -26,11 +26,11 @@ interface AgreementSubmitHandlerProps {
   redirectTo?: string;
 }
 
-export const AgreementSubmitHandler: React.FC<AgreementSubmitHandlerProps> = ({
+export const AgreementSubmitHandler = ({
   children,
   onSubmit,
   redirectTo = '/agreements',
-}) => {
+}: AgreementSubmitHandlerProps) => {
   const navigate = useNavigate();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [validationErrors, setValidationErrors] = useState<Record<string, string> | null>(null);

--- a/src/components/agreements/CustomerListFilterClone.tsx
+++ b/src/components/agreements/CustomerListFilterClone.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useEffect, useCallback, memo } from 'react';
+import type { ChangeEvent } from 'react';
 import { Input } from "@/components/ui/input";
 import { Search, X, Filter } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -26,11 +27,11 @@ interface CustomerListFilterProps {
   onFilterChange?: (filters: { [key: string]: string }) => void;
 }
 
-export const CustomerListFilterClone: React.FC<CustomerListFilterProps> = memo(({
+export const CustomerListFilterClone = memo(({
   onSearch,
   searchTerm,
   onFilterChange
-}) => {
+}: CustomerListFilterProps) => {
   const [searchValue, setSearchValue] = useState(searchTerm);
 
   // Only update search value when searchTerm prop changes
@@ -45,7 +46,7 @@ export const CustomerListFilterClone: React.FC<CustomerListFilterProps> = memo((
 
   // Handle search input change
   const handleSearchChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
+    (e: ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value;
       setSearchValue(value);
       handleDebouncedSearch(value);

--- a/src/components/agreements/ReassignmentHistoryItem.tsx
+++ b/src/components/agreements/ReassignmentHistoryItem.tsx
@@ -27,11 +27,11 @@ interface ReassignmentHistoryItemProps {
   onToggleExpand?: () => void;
 }
 
-export const ReassignmentHistoryItem: React.FC<ReassignmentHistoryItemProps> = ({
+export const ReassignmentHistoryItem = ({
   record,
   isExpanded = false,
   onToggleExpand
-}) => {
+}: ReassignmentHistoryItemProps) => {
   const formattedDate = format(new Date(record.reassignedAt), 'MMM d, yyyy • h:mm a');
   
   return (

--- a/src/components/agreements/ReassignmentWizard.tsx
+++ b/src/components/agreements/ReassignmentWizard.tsx
@@ -21,11 +21,11 @@ import type { ReassignmentWizardProps } from '@/types/reassignment.types';
  * @param onComplete - Optional callback function executed on successful reassignment
  * @param onCancel - Optional callback function executed when reassignment is cancelled
  */
-const ReassignmentWizard: React.FC<ReassignmentWizardProps> = ({ 
-  leaseId, 
-  onComplete, 
-  onCancel 
-}) => {
+const ReassignmentWizard = ({
+  leaseId,
+  onComplete,
+  onCancel
+}: ReassignmentWizardProps) => {
   const navigate = useNavigate();
   const {
     lease,

--- a/src/components/agreements/VehicleStatusBadge.tsx
+++ b/src/components/agreements/VehicleStatusBadge.tsx
@@ -26,12 +26,12 @@ interface VehicleStatusBadgeProps {
   showIcon?: boolean;
 }
 
-export const VehicleStatusBadge: React.FC<VehicleStatusBadgeProps> = ({
+export const VehicleStatusBadge = ({
   status,
   className = '',
   size = 'md',
   showIcon = true
-}) => {
+}: VehicleStatusBadgeProps) => {
   const getStatusConfig = (status: VehicleStatusType) => {
     const lowerStatus = status.toLowerCase();
     

--- a/src/components/agreements/form/AgreementBasicDetails.tsx
+++ b/src/components/agreements/form/AgreementBasicDetails.tsx
@@ -18,12 +18,12 @@ interface AgreementBasicDetailsProps {
   onCustomerChange: (customerId: string, customerData: CustomerInfo) => void;
 }
 
-export const AgreementBasicDetails: React.FC<AgreementBasicDetailsProps> = ({ 
-  form, 
+export const AgreementBasicDetails = ({
+  form,
   isEdit,
   onVehicleChange,
   onCustomerChange
-}) => {
+}: AgreementBasicDetailsProps) => {
   const { customers, isLoading: isLoadingCustomers } = useCustomers();
   const vehiclesHook = useVehicles();
   const { data: vehicles, isLoading: isLoadingVehicles } = vehiclesHook.useList();

--- a/src/components/agreements/form/AgreementContractTerms.tsx
+++ b/src/components/agreements/form/AgreementContractTerms.tsx
@@ -14,11 +14,11 @@ interface AgreementContractTermsProps {
   setTermsAccepted: (value: boolean) => void;
 }
 
-export const AgreementContractTerms: React.FC<AgreementContractTermsProps> = ({ 
-  form, 
-  termsAccepted, 
-  setTermsAccepted 
-}) => {
+export const AgreementContractTerms = ({
+  form,
+  termsAccepted,
+  setTermsAccepted
+}: AgreementContractTermsProps) => {
   return (
     <div className="bg-white p-6 rounded-lg shadow-sm border border-gray-200">
       <h2 className="text-xl font-semibold mb-4">Contract Terms & Dates</h2>

--- a/src/components/agreements/form/AgreementDetails.tsx
+++ b/src/components/agreements/form/AgreementDetails.tsx
@@ -19,7 +19,7 @@ interface AgreementDetailsProps {
   standardTemplateExists: boolean;
 }
 
-export const AgreementDetails: React.FC<AgreementDetailsProps> = ({
+export const AgreementDetails = ({
   agreementNumber,
   setAgreementNumber,
   startDate,
@@ -31,7 +31,7 @@ export const AgreementDetails: React.FC<AgreementDetailsProps> = ({
   status,
   setStatus,
   standardTemplateExists
-}) => {
+}: AgreementDetailsProps) => {
   return (
     <div className="space-y-4">
       <h3 className="font-medium text-lg">Agreement Details</h3>

--- a/src/components/agreements/form/CustomerVehicleSection.tsx
+++ b/src/components/agreements/form/CustomerVehicleSection.tsx
@@ -20,14 +20,14 @@ interface CustomerVehicleSectionProps {
   vehicleError?: string;
 }
 
-export const CustomerVehicleSection: React.FC<CustomerVehicleSectionProps> = ({
+export const CustomerVehicleSection = ({
   selectedCustomer,
   setSelectedCustomer,
   selectedVehicle,
   setSelectedVehicle,
   customerError,
   vehicleError
-}) => {
+}: CustomerVehicleSectionProps) => {
   const [open, setOpen] = useState(false);
   const [customers, setCustomers] = useState<CustomerInfo[]>([]);
   const [searchQuery, setSearchQuery] = useState('');

--- a/src/components/agreements/form/PaymentInformation.tsx
+++ b/src/components/agreements/form/PaymentInformation.tsx
@@ -19,7 +19,7 @@ interface PaymentInformationProps {
   rentError?: string;
 }
 
-export const PaymentInformation: React.FC<PaymentInformationProps> = ({
+export const PaymentInformation = ({
   rentAmount,
   setRentAmount,
   depositAmount,
@@ -31,7 +31,7 @@ export const PaymentInformation: React.FC<PaymentInformationProps> = ({
   notes,
   setNotes,
   rentError
-}) => {
+}: PaymentInformationProps) => {
   return (
     <div className="mt-8 space-y-4">
       <h3 className="font-medium text-lg">Payment Information</h3>

--- a/src/components/agreements/form/VehicleDetailsCard.tsx
+++ b/src/components/agreements/form/VehicleDetailsCard.tsx
@@ -13,7 +13,7 @@ interface VehicleDetailsCardProps {
   };
 }
 
-export const VehicleDetailsCard: React.FC<VehicleDetailsCardProps> = ({ vehicle }) => {
+export const VehicleDetailsCard = ({ vehicle }: VehicleDetailsCardProps) => {
   if (!vehicle) return null;
   
   return (

--- a/src/components/agreements/page/AgreementSearch.tsx
+++ b/src/components/agreements/page/AgreementSearch.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState } from 'react';
+import type { ChangeEvent } from 'react';
 import { Input } from "@/components/ui/input";
 import { Search, X, Filter } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -26,7 +27,7 @@ export function AgreementSearch({
   const [searchValue, setSearchValue] = useState(searchQuery);
   
   // Handle search input changes with debounce
-  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setSearchValue(value);
     

--- a/src/components/agreements/payments/PaymentScheduleEditor.tsx
+++ b/src/components/agreements/payments/PaymentScheduleEditor.tsx
@@ -34,7 +34,7 @@ interface PaymentScheduleEditorProps {
   onPaymentDayChange: (value: number) => void;
 }
 
-const PaymentScheduleEditor: React.FC<PaymentScheduleEditorProps> = ({
+const PaymentScheduleEditor = ({
   agreementId,
   startDate,
   endDate,
@@ -43,7 +43,7 @@ const PaymentScheduleEditor: React.FC<PaymentScheduleEditorProps> = ({
   paymentDay,
   onFrequencyChange,
   onPaymentDayChange,
-}) => {
+}: PaymentScheduleEditorProps) => {
   const [paymentSchedule, setPaymentSchedule] = useState<any[]>([]);
   const [isGenerating, setIsGenerating] = useState(false);
 

--- a/src/components/agreements/selectors/CustomerSelector.tsx
+++ b/src/components/agreements/selectors/CustomerSelector.tsx
@@ -15,7 +15,7 @@ interface CustomerSelectorProps {
   onChange: (value: string) => void;
 }
 
-const CustomerSelector: React.FC<CustomerSelectorProps> = ({ value, onChange }) => {
+const CustomerSelector = ({ value, onChange }: CustomerSelectorProps) => {
   const customerService = useCustomerService();
   
   const { data: customers, isLoading } = useQuery({

--- a/src/components/agreements/selectors/VehicleSelector.tsx
+++ b/src/components/agreements/selectors/VehicleSelector.tsx
@@ -18,13 +18,13 @@ interface VehicleSelectorProps {
   onVehicleSelect?: (vehicle: any) => void;
 }
 
-const VehicleSelector: React.FC<VehicleSelectorProps> = ({ 
-  value, 
-  onChange, 
+const VehicleSelector = ({
+  value,
+  onChange,
   placeholder = "Select a vehicle",
   selectedVehicle,
   onVehicleSelect
-}) => {
+}: VehicleSelectorProps) => {
   const { data: vehicles, isLoading } = useQuery({
     queryKey: ['vehicles'],
     queryFn: async () => {

--- a/src/components/agreements/terms/AgreementTermsEditor.tsx
+++ b/src/components/agreements/terms/AgreementTermsEditor.tsx
@@ -14,12 +14,12 @@ interface AgreementTermsEditorProps {
   onAdditionalDriversChange: (drivers: string[]) => void;
 }
 
-const AgreementTermsEditor: React.FC<AgreementTermsEditorProps> = ({
+const AgreementTermsEditor = ({
   termsAccepted,
   onTermsAcceptedChange,
   additionalDrivers,
   onAdditionalDriversChange,
-}) => {
+}: AgreementTermsEditorProps) => {
   const [newDriver, setNewDriver] = React.useState('');
 
   const handleAddDriver = () => {


### PR DESCRIPTION
## Summary
- remove deprecated `React.FC` usage
- import React change/event types explicitly
- adjust `useState` calls to avoid generic usage

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)* 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances type safety in React components by removing deprecated usage of React.FC and explicitly importing necessary types like FormEvent and ChangeEvent. It also refactors useState calls to eliminate generic types, improving maintainability and readability of the codebase.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily focus on type improvements, making the review process relatively simple.
</div>