### PR TITLE
Fix vehicle repository import

### DIFF
--- a/src/lib/database/repositories/vehicle-repository.ts
+++ b/src/lib/database/repositories/vehicle-repository.ts
@@ -1,7 +1,7 @@
 
 import { Repository } from '../repository';
 import { Tables, TableRow, DbListResponse, DbSingleResponse } from '../types';
-import { asVehicleId, asVehicleStatus } from '../utils';
+import { asVehicleId, asVehicleStatus } from '../database-types';
 import { supabase } from '@/lib/supabase';
 import type { PostgrestError } from '@supabase/supabase-js';
 


### PR DESCRIPTION
## Summary
- import `asVehicleId` from `database-types`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*