### PR TITLE
Fix badge types and improve CSV dropzone typing

### DIFF
--- a/src/components/agreements/AgreementSubmitHandler.tsx
+++ b/src/components/agreements/AgreementSubmitHandler.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState, useCallback } from 'react';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Agreement } from '@/lib/validation-schemas/agreement';
 import { agreementService } from '@/services/AgreementService';
@@ -18,7 +19,7 @@ interface AgreementSubmitHandlerProps {
     isSubmitting: boolean;
     updateProgress?: (progress: number) => void;
     validationErrors?: Record<string, string> | null;
-  }) => React.ReactNode;
+  }) => ReactNode;
   id?: string;
   agreement?: Agreement;
   userId?: string;

--- a/src/components/agreements/CSVImportModal.tsx
+++ b/src/components/agreements/CSVImportModal.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
 import { useDropzone } from 'react-dropzone';
+import type { DropzoneOptions } from 'react-dropzone';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { toast } from 'sonner';
@@ -48,7 +49,7 @@ export function CSVImportModal({ open, onOpenChange, onImportComplete }: CSVImpo
         setShowPreview(false);
       }
     },
-  });
+  } as DropzoneOptions);
 
   const handlePreviewFile = async () => {
     if (!file) return;

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -32,12 +32,12 @@ export interface BadgeProps
   children?: React.ReactNode;
 }
 
-function Badge({ className, variant, children, ...props }: BadgeProps) {
+const Badge: React.FC<BadgeProps> = ({ className, variant, children, ...props }) => {
   return (
     <div className={cn(badgeVariants({ variant }), className)} {...props}>
       {children}
     </div>
   )
 }
-
 export { Badge, badgeVariants }
+export type { BadgeProps }


### PR DESCRIPTION
## Summary
- add explicit BadgeProps export and convert to React.FC
- use typed ReactNode in AgreementSubmitHandler
- import DropzoneOptions in CSVImportModal and cast config

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest not found)*
- `npm run type-check` 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances type safety by introducing explicit type definitions across several components, including the Badge, AgreementSubmitHandler, and CSVImportModal. These updates aim to improve code maintainability and reduce type-related errors.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved type annotations and type exports for better TypeScript support in various components. No changes to runtime behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->