### PR TITLE
Fix payment types and component props

### DIFF
--- a/src/components/agreements/AgreementDetail.tsx
+++ b/src/components/agreements/AgreementDetail.tsx
@@ -343,7 +343,11 @@ export function AgreementDetail({
 
       {agreement.id && <Card>
           <CardContent className="pt-6">
-            <AgreementTrafficFines agreementId={agreement.id} />
+            <AgreementTrafficFines
+              agreementId={agreement.id}
+              startDate={leaseStartDate}
+              endDate={leaseEndDate}
+            />
           </CardContent>
         </Card>}
 

--- a/src/components/agreements/AgreementTrafficFines.tsx
+++ b/src/components/agreements/AgreementTrafficFines.tsx
@@ -6,8 +6,8 @@ import { Loader2 } from 'lucide-react';
 
 interface AgreementTrafficFinesProps {
   agreementId: string;
-  startDate?: Date;
-  endDate?: Date;
+  startDate: Date;
+  endDate: Date;
 }
 
 export function AgreementTrafficFines({ agreementId, startDate, endDate }: AgreementTrafficFinesProps) {
@@ -31,8 +31,13 @@ export function AgreementTrafficFines({ agreementId, startDate, endDate }: Agree
   // Memoize the filtered fines to prevent recalculation on each render
   const filteredFines = React.useMemo(() => {
     if (!trafficFines) return [];
-    return trafficFines.filter(fine => fine.leaseId === agreementId);
-  }, [trafficFines, agreementId]);
+    return trafficFines.filter(
+      fine =>
+        fine.leaseId === agreementId &&
+        new Date(fine.violationDate) >= startDate &&
+        new Date(fine.violationDate) <= endDate
+    );
+  }, [trafficFines, agreementId, startDate, endDate]);
 
   if (showLoader) {
     return (

--- a/src/components/agreements/PaymentEntryDialog.tsx
+++ b/src/components/agreements/PaymentEntryDialog.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { FormField, FormGroup, FormRow, FormSection } from '@/components/ui/form-components';
 import { Input } from "@/components/ui/input";
-import { Payment } from '@/types/payment-history.types';
+import { Payment } from '@/types/payment.types';
 import { 
   Select,
   SelectContent,

--- a/src/lib/microservices/payment-service-client.ts
+++ b/src/lib/microservices/payment-service-client.ts
@@ -49,8 +49,8 @@ export class PaymentServiceClient {
           .insert(payment)
           .select()
           .single();
-        
-        return { data: data as PaymentRow || null, error };
+
+        return { data: data as PaymentRow | null, error };
       }
     } catch (error) {
       console.error('Error creating payment:', error);
@@ -82,8 +82,8 @@ export class PaymentServiceClient {
           .select('*')
           .eq('agreement_id', agreementId)
           .order('due_date', { ascending: true });
-        
-        return { data: data as PaymentRow[] || null, error };
+
+        return { data: data as PaymentRow[] | null, error };
       }
     } catch (error) {
       console.error('Error fetching payments:', error);
@@ -119,8 +119,8 @@ export class PaymentServiceClient {
           .eq('id', id)
           .select()
           .single();
-        
-        return { data: data as PaymentRow || null, error };
+
+        return { data: data as PaymentRow | null, error };
       }
     } catch (error) {
       console.error('Error updating payment:', error);
@@ -192,8 +192,8 @@ export class PaymentServiceClient {
           .eq('id', id)
           .select()
           .single();
-        
-        return { data: data as PaymentRow || null, error };
+
+        return { data: data as PaymentRow | null, error };
       }
     } catch (error) {
       console.error('Error updating payment status:', error);

--- a/src/types/payment-history.types.ts
+++ b/src/types/payment-history.types.ts
@@ -1,23 +1,6 @@
-export interface PaymentHistoryItem {
-  id: string;
-  amount: number;
-  amount_paid?: number;
-  payment_date?: string | null; // Updated to handle null values
-  due_date?: string | null; // Updated to handle null values
-  status: string; // 'completed', 'pending', 'overdue', etc.
-  lease_id?: string;
-  type?: string;
-  description?: string;
-  payment_method?: string;
-  transaction_id?: string;
-  late_fine_amount?: number;
-  days_overdue?: number;
-  balance?: number;
-  next_payment_date?: string | null; // Updated to handle null values
-  reference_number?: string;
-  notes?: string;
-  original_due_date?: string | null; // Added this field to fix the TypeScript error
-}
+import { Payment } from './payment.types';
+
+export type PaymentHistoryItem = Payment;
 
 export interface PaymentHistoryResponse {
   data: PaymentHistoryItem[];
@@ -36,6 +19,4 @@ export interface PaymentSchedule {
   balance?: number;
 }
 
-export interface Payment extends PaymentHistoryItem {
-  // Additional fields specific to Payment if needed
-}
+export type Payment = PaymentHistoryItem;

--- a/src/types/payment-types.unified.ts
+++ b/src/types/payment-types.unified.ts
@@ -69,4 +69,4 @@ export interface SpecialPaymentOptions {
 }
 
 // Re-export types for backward compatibility
-export type { Payment as PaymentHistoryItem } from '@/types/payment-history.types';
+export type { Payment as PaymentHistoryItem } from './payment.types';

--- a/src/types/payment.types.ts
+++ b/src/types/payment.types.ts
@@ -1,4 +1,54 @@
 
+import { Database } from './database.types';
+import { DbId } from '@/types/database-common';
+
+export type PaymentRow = Database['public']['Tables']['unified_payments']['Row'];
+export type PaymentInsert = Database['public']['Tables']['unified_payments']['Insert'];
+export type PaymentUpdate = Database['public']['Tables']['unified_payments']['Update'];
+
+export enum PaymentStatus {
+  PENDING = 'pending',
+  COMPLETED = 'completed',
+  PARTIALLY_PAID = 'partially_paid',
+  OVERDUE = 'overdue',
+  CANCELLED = 'cancelled',
+  VOIDED = 'voided'
+}
+
+export interface Payment {
+  id: DbId;
+  amount: number;
+  amount_paid?: number;
+  payment_date?: string | null;
+  due_date?: string | null;
+  status: PaymentStatus;
+  lease_id?: DbId;
+  type?: string;
+  description?: string;
+  payment_method?: string;
+  transaction_id?: string | null;
+  late_fine_amount?: number;
+  days_overdue?: number;
+  balance?: number;
+  next_payment_date?: string | null;
+  reference_number?: string;
+  notes?: string;
+  original_due_date?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface PaymentMetrics {
+  totalAmount: number;
+  amountPaid: number;
+  balance: number;
+  lateFees: number;
+  paidOnTime: number;
+  paidLate: number;
+  unpaid: number;
+  totalPayments: number;
+}
+
 export interface SpecialPaymentOptions {
   notes?: string;
   paymentMethod?: string;
@@ -9,32 +59,4 @@ export interface SpecialPaymentOptions {
   targetPaymentId?: string;
 }
 
-export type PaymentStatus =
-  | 'pending'
-  | 'completed'
-  | 'overdue'
-  | 'cancelled'
-  | 'partially_paid'
-  | 'voided';
-
-export interface Payment {
-  id: string;
-  lease_id: string;
-  amount: number;
-  amount_paid?: number;
-  payment_date: string;
-  description?: string;
-  payment_method?: string;
-  reference_number?: string;
-  status: PaymentStatus;
-  type?: string;
-  days_overdue?: number;
-  late_fine_amount?: number;
-  due_date?: string;
-  original_due_date?: string;
-  created_at?: string;
-  updated_at?: string;
-}
-
-export type PaymentInsert = Omit<Payment, 'id'>;
-export type PaymentUpdate = Partial<Payment>;
+export type { Payment as PaymentHistoryItem } from './payment-history.types';

--- a/src/types/vehicle-assignment.types.ts
+++ b/src/types/vehicle-assignment.types.ts
@@ -1,5 +1,5 @@
 
-import { Payment } from './payment-history.types';
+import { Payment } from './payment.types';
 import { TrafficFine } from '@/hooks/use-traffic-fines';
 
 export interface VehicleInfo {


### PR DESCRIPTION
## Summary
- consolidate payment type definitions
- update traffic fine component to require date props
- pass dates to `AgreementTrafficFines`
- clean up Supabase type casts
- adjust imports for new payment types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check`
- `npm test` *(fails: vitest not found)*