### PR TITLE
Fix CustomerDetail edit button

### DIFF
--- a/src/components/customers/CustomerDetail.tsx
+++ b/src/components/customers/CustomerDetail.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { 
   Card, CardContent, 
   Badge, Button, 
@@ -31,7 +32,6 @@ const updateCustomer = (id: string, data: any) => {
 };
 
 export const CustomerDetail: React.FC<CustomerDetailProps> = ({ customerId }) => {
-  const [isEditing, setIsEditing] = useState(false);
   const [customer, setCustomer] = useState<any>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -243,9 +243,11 @@ export const CustomerDetail: React.FC<CustomerDetailProps> = ({ customerId }) =>
               </div>
             </div>
             <div className="flex gap-2 mt-4 md:mt-0">
-              <Button variant="outline" onClick={() => setIsEditing(true)}>
-                <Edit className="mr-2 h-4 w-4" />
-                Edit
+              <Button asChild variant="outline">
+                <Link to={`/customers/edit/${customerId}`}> 
+                  <Edit className="mr-2 h-4 w-4" />
+                  Edit
+                </Link>
               </Button>
               <Button variant="destructive" onClick={handleDelete}>
                 <Trash2 className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- update CustomerDetail button to link to the edit page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')* 
 <div id='description'>
<h3>Summary by Bito</h3>
This pull request enhances the customer editing experience by linking the edit button in the CustomerDetail component directly to the edit page using a React Router Link. It also simplifies state management by removing the local editing state.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the "Edit" button in the customer detail view to navigate to a dedicated edit page instead of toggling inline editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->