### PR TITLE
Fix missing profile status export

### DIFF
--- a/src/lib/database/utils.ts
+++ b/src/lib/database/utils.ts
@@ -34,3 +34,36 @@ export function asVehicleStatus(status: string): VehicleStatus {
 export function isValidVehicleStatus(status: string): boolean {
   return VEHICLE_STATUSES.includes(status.toLowerCase() as VehicleStatus);
 }
+
+// Valid profile statuses
+const PROFILE_STATUSES = [
+  'active',
+  'inactive',
+  'blacklisted',
+  'pending_review',
+  'pending_payment'
+] as const;
+
+type ProfileStatus = typeof PROFILE_STATUSES[number];
+
+/**
+ * Validates and returns a profile status
+ * @param status Status to validate
+ * @returns Valid profile status or default 'active'
+ */
+export function asProfileStatus(status: string): ProfileStatus {
+  if (!status) return 'active';
+
+  const normalizedStatus = status.toLowerCase();
+
+  if (PROFILE_STATUSES.includes(normalizedStatus as ProfileStatus)) {
+    return normalizedStatus as ProfileStatus;
+  }
+
+  console.warn(`Invalid profile status: ${status}. Defaulting to 'active'`);
+  return 'active';
+}
+
+export function isValidProfileStatus(status: string): boolean {
+  return PROFILE_STATUSES.includes(status.toLowerCase() as ProfileStatus);
+}


### PR DESCRIPTION
## Summary
- add profile status helpers in `database/utils`

## Testing
- `npm run type-check`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*