### PR TITLE
Fix missing pdf font reference

### DIFF
--- a/src/utils/agreement-report-utils.ts
+++ b/src/utils/agreement-report-utils.ts
@@ -13,9 +13,9 @@ export async function ensureFontsLoaded() {
   try {
     (pdfMake as any).fonts = {
   Amiri: {
-        normal: 'Amiri-normal.ttf',
+        normal: 'Amiri-Regular.ttf',
     bold: 'Amiri-Bold.ttf',
-        italics: 'Amiri-normal.ttf',
+        italics: 'Amiri-Regular.ttf',
         bolditalics: 'Amiri-Bold.ttf',
       },
     };


### PR DESCRIPTION
## Summary
- fix pdf font file reference so pdfMake can find loaded fonts

## Testing
- `npm run check-boundaries`


------
https://chatgpt.com/codex/tasks/task_e_683f66d406388328b5181d1a8b97195b 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request fixes a bug related to PDF font file references in the agreement report utility by ensuring the correct 'Amiri' font files are referenced, allowing pdfMake to load the necessary fonts without errors.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the font configuration for the "Amiri" font family, ensuring improved consistency in font appearance for generated PDF documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->