### PR TITLE
Fix PDF fonts

### DIFF
--- a/src/utils/agreement-report-utils.ts
+++ b/src/utils/agreement-report-utils.ts
@@ -592,6 +592,7 @@ export async function generateAgreementReportPdfmake(
     },
     
     defaultStyle: {
+      font: 'Amiri',
       fontSize: 11,
       rtl: true,
       alignment: 'right',

--- a/src/utils/agreementUtils.ts
+++ b/src/utils/agreementUtils.ts
@@ -397,6 +397,7 @@ export async function generatePdfDocument(agreement: Agreement): Promise<boolean
       },
       
       defaultStyle: {
+        font: 'Amiri',
         fontSize: 11,
         lineHeight: 1.3
       }

--- a/src/utils/generateAgreementPdf.ts
+++ b/src/utils/generateAgreementPdf.ts
@@ -460,8 +460,9 @@ export async function generateAgreementPdfAndUploadAndDownload({ agreement, cust
       }
     },
     
-    // Default style WITHOUT font specification - uses pdfMake defaults
+    // Default style WITH Arabic font for proper shaping
     defaultStyle: {
+      font: 'Amiri',
       fontSize: 11,
       lineHeight: 1.3,
       alignment: 'right'


### PR DESCRIPTION
## Summary
- ensure Arabic-aware fonts are used in doc generation
- specify 'Amiri' as default font in agreement utilities

## Testing
- `npm run check-boundaries`

------
https://chatgpt.com/codex/tasks/task_e_68484ee814948328bf56452869bc1e38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the default font in generated PDF documents to "Amiri" for improved Arabic text rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai --> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances PDF generation by setting the 'Amiri' font as the default for improved Arabic text rendering. Modifications were made to the default styles in various utility files related to agreement reports and PDF generation.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve font settings, making the review process relatively simple.
-->
</div>