### PR TITLE
Add development build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "check-boundaries": "tsc --noEmit",
     "start:server": "cd server && npm start",
     "dev:server": "cd server && npm run dev",
-    "dev:all": "concurrently \"npm run dev\" \"npm run dev:server\""
+    "dev:all": "concurrently \"npm run dev\" \"npm run dev:server\"",
+    "build:dev": "vite build --mode development"
   },
   "dependencies": {
     "@eslint/js": "^9.28.0",


### PR DESCRIPTION
## Summary
- add a `build:dev` script for dev-mode builds

## Testing
- `node -e "console.log(require('./package.json').scripts)"`

------
https://chatgpt.com/codex/tasks/task_e_6849cb25f5d08328936f43d08a273a28